### PR TITLE
Add in examples of jms, database and cloud storage connection properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-
+.idea
 .DS_Store

--- a/docs/README.md
+++ b/docs/README.md
@@ -223,7 +223,7 @@ dataset:
 | dataset.table.columns.column.criticalDataElementStatus |             | No       | True or false indicator; If element is considered a critical data element (CDE) then true else false.                                                                                                                                                 |
 | dataset.table.columns.column.tags                      |             | No       | A list of tags that may be assigned to the dataset, table or column; the tags keyword may appear at any level.                                                                                                                                        |
 
-### Authorative definitions
+### Authoritative definitions
 
 Updated in ODCS (Open Data Contract Standard) v2.3.0.
 

--- a/examples/fundamentals/cloud-storage-connection.yaml
+++ b/examples/fundamentals/cloud-storage-connection.yaml
@@ -1,0 +1,8 @@
+type: files
+
+connectionProperties:
+  bucket: my-big-data-bucket
+  endpoint: s3.us-east-1.amazonaws.com
+  credentialsProvider: org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider
+  accessKey: my-access
+  secretKey: my-secret

--- a/examples/fundamentals/cloud-storage-connection.yaml
+++ b/examples/fundamentals/cloud-storage-connection.yaml
@@ -1,3 +1,5 @@
+sourcePlatform: aws-s3
+sourceSystem: s3
 type: files
 
 connectionProperties:

--- a/examples/fundamentals/database-connection.yaml
+++ b/examples/fundamentals/database-connection.yaml
@@ -1,0 +1,12 @@
+type: tables
+
+# based on the type of the dataset, connection properties will be different. For example, database connection will have driver, server, database
+# Kafka would have bootstrapServers, etc.
+# need to define common set of valid connection properties per type
+connectionProperties:
+  driver: null
+  driverVersion: null
+  server: null
+  database: pypl-edw.pp_access_views
+  username: '${env.username}'
+  password: '${env.password}'

--- a/examples/fundamentals/database-connection.yaml
+++ b/examples/fundamentals/database-connection.yaml
@@ -1,3 +1,5 @@
+sourcePlatform: aws-rds
+sourceSystem: postgres
 type: tables
 
 # based on the type of the dataset, connection properties will be different. For example, database connection will have driver, server, database

--- a/examples/fundamentals/jms-connection.yaml
+++ b/examples/fundamentals/jms-connection.yaml
@@ -1,3 +1,5 @@
+sourcePlatform: kubernetes
+sourceSystem: solace
 type: jms-destination
 
 connectionProperties:

--- a/examples/fundamentals/jms-connection.yaml
+++ b/examples/fundamentals/jms-connection.yaml
@@ -1,0 +1,9 @@
+type: jms-destination
+
+connectionProperties:
+  connectionFactory: /jms/cf/default
+  initialContextFactory: com.solacesystems.jndi.SolJNDIInitialContextFactory
+  url: smf://localhost:55554
+  vpnName: default
+  username: admin
+  password: admin


### PR DESCRIPTION
Proposal for generic connection properties. It would be based on the type of the data contract. The `connectionProperties` is a map of key value pairs where the keys are some pre-defined set of required/optional keys.
Maybe need to encompass `sourceSystem` and `sourcePlatform` as well to determine what `connectionProperties` are valid. For example,
```
sourcePlatform: aws-rds
sourceSystem: postgres
type: tables
connectionProperties:
  driver: ...
```