### PR TITLE
Quality: Rename type implicit to library

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -299,12 +299,12 @@ This section describes data quality rules & parameters. They are tightly linked 
 
 Data quality rules support different levels/stages of data quality attributes:
   - __Text__: A human-readable text that describes the quality of the data.
-  - __Implicit__ rules: A maintained library of commonly-used predefined quality attributes such as `rowCount`, `unique`, `freshness`, and more.
+  - __Default__ rules: A maintained library of commonly-used predefined quality attributes such as `rowCount`, `unique`, `freshness`, and more.
   - __SQL__: An individual SQL query that returns a value that can be compared. Can be extended to `Python` or other.
   - __Custom__: Quality attributes that are vendor-specific, such as Soda, Great Expectations, dbt tests, or Montecarlo monitors.
 
 ### Text
-A human-readable text that describes the quality of the data. Later in the development process, these might be translated into an executable check (such as `sql`), an implicit rule, or checked through an AI engine.
+A human-readable text that describes the quality of the data. Later in the development process, these might be translated into an executable check (such as `sql`), a default rule, or checked through an AI engine.
 
 ```yaml
 quality:
@@ -312,8 +312,8 @@ quality:
     description: The email address was verified by the system.
 ```
 
-### Implicit data quality rules
-ODCS will provide a set of predefined (or implicit) rules commonly used in data quality checks, designed to be compatible with all major data quality engines. This simplifies the work for data engineers by eliminating the need to manually write SQL queries.
+### Default data quality rules
+ODCS will provide a set of predefined rules commonly used in data quality checks, designed to be compatible with all major data quality engines. This simplifies the work for data engineers by eliminating the need to manually write SQL queries.
 
 #### Property-level
 Those examples apply at the property level, such as column, field, etc.
@@ -323,7 +323,7 @@ No more than 10 duplicate names.
 
 ```yaml
 quality:
-- type: implicit # optional and default value for data quality rules
+- type: default # optional and default value for data quality rules
   rule: duplicateCount
   mustBeLessThan: 10
   name: Fewer than 10 duplicate names
@@ -427,8 +427,8 @@ Acronyms:
 |quality                         |Quality                   | No     | Quality tag with all the relevant information for rule setup and execution.                                                                                                         |
 |quality.name                    |Name                      | No     | A short name for the rule.                                                                                                                                                          |
 |quality.description             |Description               | No     | Describe the quality check to be completed.                                                                                                                                         |
-|quality.type                    |Type                      | No     | Type of DQ rule. Valid values are `implicit` (default), `text`, `sql`, and `custom`.                                                                                                |
-|quality.rule                    |Rule name                 | No     | Required for `implicit` DQ rules: the name of the rule to be executed.                                                                                                              |
+|quality.type                    |Type                      | No     | Type of DQ rule. Valid values are `default` (default), `text`, `sql`, and `custom`.                                                                                                |
+|quality.rule                    |Rule name                 | No     | Required for `default` DQ rules: the name of the rule to be executed.                                                                                                              |
 |quality.\<operator>             |See below                 | No     | Multiple values are allowed for the **property**, the value is the one to compare to.                                                                                               |
 |quality.unit                    |Unit                      | No     | Unit the rule is using, popular values are `rows` or `percent`, but any value is allowed.                                                                                           |
 |quality.validValues             |Valid values              | No     | Static list of valid values.                                                                                                                                                        |
@@ -492,8 +492,8 @@ quality:
 ```
 
 
-#### Implicit Rules
-Bitol has the ambition of creating a standard set of implicit data quality rules. Join the working group around [RFC #0012](https://github.com/bitol-io/tsc/blob/main/rfcs/0012-implicit-dq-rules.md).
+#### Default Rules
+Bitol has the ambition of creating a standard set of default data quality rules. Join the working group around [RFC #0012](https://github.com/bitol-io/tsc/blob/main/rfcs/0012-implicit-dq-rules.md).
 
 
 ## <a id="support"/> Support & communication channels

--- a/docs/README.md
+++ b/docs/README.md
@@ -299,12 +299,12 @@ This section describes data quality rules & parameters. They are tightly linked 
 
 Data quality rules support different levels/stages of data quality attributes:
   - __Text__: A human-readable text that describes the quality of the data.
-  - __Default__ rules: A maintained library of commonly-used predefined quality attributes such as `rowCount`, `unique`, `freshness`, and more.
+  - __Library__ rules: A maintained library of commonly-used predefined quality attributes such as `rowCount`, `unique`, `freshness`, and more.
   - __SQL__: An individual SQL query that returns a value that can be compared. Can be extended to `Python` or other.
   - __Custom__: Quality attributes that are vendor-specific, such as Soda, Great Expectations, dbt tests, or Montecarlo monitors.
 
 ### Text
-A human-readable text that describes the quality of the data. Later in the development process, these might be translated into an executable check (such as `sql`), a default rule, or checked through an AI engine.
+A human-readable text that describes the quality of the data. Later in the development process, these might be translated into an executable check (such as `sql`), a library rule, or checked through an AI engine.
 
 ```yaml
 quality:
@@ -312,7 +312,7 @@ quality:
     description: The email address was verified by the system.
 ```
 
-### Default data quality rules
+### Library
 ODCS will provide a set of predefined rules commonly used in data quality checks, designed to be compatible with all major data quality engines. This simplifies the work for data engineers by eliminating the need to manually write SQL queries.
 
 #### Property-level
@@ -323,7 +323,7 @@ No more than 10 duplicate names.
 
 ```yaml
 quality:
-- type: default # optional and default value for data quality rules
+- type: library # optional and default value for data quality rules
   rule: duplicateCount
   mustBeLessThan: 10
   name: Fewer than 10 duplicate names
@@ -427,8 +427,8 @@ Acronyms:
 |quality                         |Quality                   | No     | Quality tag with all the relevant information for rule setup and execution.                                                                                                         |
 |quality.name                    |Name                      | No     | A short name for the rule.                                                                                                                                                          |
 |quality.description             |Description               | No     | Describe the quality check to be completed.                                                                                                                                         |
-|quality.type                    |Type                      | No     | Type of DQ rule. Valid values are `default` (default), `text`, `sql`, and `custom`.                                                                                                |
-|quality.rule                    |Rule name                 | No     | Required for `default` DQ rules: the name of the rule to be executed.                                                                                                              |
+|quality.type                    |Type                      | No     | Type of DQ rule. Valid values are `library` (default), `text`, `sql`, and `custom`.                                                                                                |
+|quality.rule                    |Rule name                 | No     | Required for `library` DQ rules: the name of the rule to be executed.                                                                                                              |
 |quality.\<operator>             |See below                 | No     | Multiple values are allowed for the **property**, the value is the one to compare to.                                                                                               |
 |quality.unit                    |Unit                      | No     | Unit the rule is using, popular values are `rows` or `percent`, but any value is allowed.                                                                                           |
 |quality.validValues             |Valid values              | No     | Static list of valid values.                                                                                                                                                        |
@@ -492,8 +492,8 @@ quality:
 ```
 
 
-#### Default Rules
-Bitol has the ambition of creating a standard set of default data quality rules. Join the working group around [RFC #0012](https://github.com/bitol-io/tsc/blob/main/rfcs/0012-implicit-dq-rules.md).
+#### Library Rules
+Bitol has the ambition of creating a library of common data quality rules. Join the working group around [RFC #0012](https://github.com/bitol-io/tsc/blob/main/rfcs/0012-implicit-dq-rules.md).
 
 
 ## <a id="support"/> Support & communication channels

--- a/schema/odcs-json-schema-v3.0.0.json
+++ b/schema/odcs-json-schema-v3.0.0.json
@@ -1808,8 +1808,8 @@
         "type": {
           "type": "string",
           "description": "The type of quality check.",
-          "enum": ["text", "predefined", "sql", "custom"],
-          "default": "predefined"
+          "enum": ["text", "library", "sql", "custom"],
+          "default": "library"
         },
         "name": {
           "type": "string",
@@ -1867,12 +1867,12 @@
           "if": {
             "properties": {
               "type": {
-                "const": "predefined"
+                "const": "library"
               }
             }
           },
           "then": {
-            "$ref": "#/$defs/DataQualityPredefined"
+            "$ref": "#/$defs/DataQualityLibrary"
           }
         },
         {
@@ -1910,7 +1910,7 @@
         "$ref": "#/$defs/DataQuality"
       }
     },
-    "DataQualityPredefined": {
+    "DataQualityLibrary": {
       "type": "object",
       "properties": {
         "rule": {


### PR DESCRIPTION
I would like to create this sub RFC and propose to rename the quality type implicit to quality 

```
quality:
- type: implicit
  rule: rowCount
```
to
```
quality:
- type: library
  rule: rowCount
```


