### PR TITLE
add Expressing Date / Datetime / Timezone information to readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ image: "https://raw.githubusercontent.com/bitol-io/artwork/main/horizontal/color
 
 This document tracks the history and evolution of the **Open Data Contract Standard**.
 
-# v3.0.0 - 2024-10-05 - APPROVED
+# v3.0.0 - 2024-10-21 - APPROVED
 
 * **New section**: Support & communication channels.
 * **New section**: Servers.

--- a/docs/README.md
+++ b/docs/README.md
@@ -291,7 +291,7 @@ Additional metadata options to more accurately define the data type.
 
 #### Expressing Date / Datetime / Timezone information
 
-Given the complexity of handling various date and time formats (e.g., date, datetime, time, timestamp, timestamp with and without timezone), the existing `logicalType` options currently support only `date`. To specify additional temporal details, `logicalType` should be used in conjunction with `logicalTypeOptions.format` to define the desired format.
+Given the complexity of handling various date and time formats (e.g., date, datetime, time, timestamp, timestamp with and without timezone), the existing `logicalType` options currently support only `date`. To specify additional temporal details, `logicalType` should be used in conjunction with `logicalTypeOptions.format`  or `physicalType` to define the desired format. Using `physicalType` allows for definition of your data-source specific data type.  
 
 ``` yaml
 version: 1.0.0
@@ -324,6 +324,15 @@ schema:
       - format: "HH:mm:ss"
     examples:
       - "08:30:00"
+
+    # Physical Type with Date & Time (UTC)
+  - name: event_date
+    logicalType: date
+    physicalType: DATETIME
+    logicalTypeOptions:
+      - format: yyyy-MM-ddTHH:mm:ssZ"
+    examples:
+      - "2024-03-10T14:22:35Z"
 
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -289,6 +289,44 @@ Additional metadata options to more accurately define the data type.
 | string         | minLength        | Minimum Length     | No       | Minimum length of the string.                                                                                                                                                                         |
 | string         | pattern          | Pattern            | No       | Regular expression pattern to define valid value. Follows regular expression syntax from ECMA-262 (https://262.ecma-international.org/5.1/#sec-15.10.1).                                              |
 
+#### Expressing Date / Datetime / Timezone information
+
+Given the complexity of handling various date and time formats (e.g., date, datetime, time, timestamp, timestamp with and without timezone), the existing `logicalType` options currently support only `date`. To specify additional temporal details, `logicalType` should be used in conjunction with `logicalTypeOptions.format` to define the desired format.
+
+``` yaml
+version: 1.0.0
+kind: DataContract
+id: 53581432-6c55-4ba2-a65f-72344a91553a
+status: active
+name: date_example
+apiVersion: v3.0.1
+schema:
+  # Date Only 
+  - name: event_date
+    logicalType: date
+    logicalTypeOptions:
+      - format: "YYYY-MM-DD"
+    examples:
+      - "2024-07-10"
+
+  # Date & Time (UTC)  
+  - name: created_at
+    logicalType: date
+    logicalTypeOptions:
+      - format: "YYYY-MM-DDTHH:MM:SSZ"
+    examples:
+      - "2024-03-10T14:22:35Z"
+
+  # Time Only 
+  - name: event_start_time
+    logicalType: date
+    logicalTypeOptions:
+      - format: "HH:MM:SS"
+    examples:
+      - "08:30:00"
+
+```
+
 ### Authoritative definitions
 
 Reference to an external definition on element logic or values.

--- a/docs/README.md
+++ b/docs/README.md
@@ -305,7 +305,7 @@ schema:
   - name: event_date
     logicalType: date
     logicalTypeOptions:
-      - format: "YYYY-MM-DD"
+      - format: "yyyy-MM-dd"
     examples:
       - "2024-07-10"
 
@@ -313,7 +313,7 @@ schema:
   - name: created_at
     logicalType: date
     logicalTypeOptions:
-      - format: "YYYY-MM-DDTHH:MM:SSZ"
+      - format: "yyyy-MM-ddTHH:mm:ssZ"
     examples:
       - "2024-03-10T14:22:35Z"
 
@@ -321,7 +321,7 @@ schema:
   - name: event_start_time
     logicalType: date
     logicalTypeOptions:
-      - format: "HH:MM:SS"
+      - format: "HH:mm:ss"
     examples:
       - "08:30:00"
 


### PR DESCRIPTION
Given the discussions we have been having across the slack, I am added in a section on how to express Date / Datetime / Timezone information  in conjunction with `logicalTypeOptions.format` to the readme. 

This is based on input from @pflooky and @jochenchrist 