### PR TITLE
Rename title from 'AthenaServer' to 'ApiServer'

### DIFF
--- a/schema/odcs-json-schema-v3.1.0.json
+++ b/schema/odcs-json-schema-v3.1.0.json
@@ -652,7 +652,7 @@
     "ServerSource": {
       "ApiServer": {
         "type": "object",
-        "title": "AthenaServer",
+        "title": "ApiServer",
         "properties": {
           "location": {
             "type": "string",


### PR DESCRIPTION
Small no-impact change, just for better documentation/readability.

The `title` property of the `ApiServer` object definition had a confusing/wrong value.