### PR TITLE
fix: update shorthand regex in schema to allow for multiple namespace (#239)

### DIFF
--- a/schema/odcs-json-schema-latest.json
+++ b/schema/odcs-json-schema-latest.json
@@ -149,7 +149,7 @@
     "ShorthandReference": {
       "type": "string",
       "description": "Shorthand notation using name fields (table_name.column_name)",
-      "pattern": "^[A-Za-z_][A-Za-z0-9_]*\\.[A-Za-z_][A-Za-z0-9_]*$"
+      "pattern": "^[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)+$"
     },
     "FullyQualifiedReference": {
       "type": "string",

--- a/schema/odcs-json-schema-v3.1.0.json
+++ b/schema/odcs-json-schema-v3.1.0.json
@@ -149,7 +149,7 @@
     "ShorthandReference": {
       "type": "string",
       "description": "Shorthand notation using name fields (table_name.column_name)",
-      "pattern": "^[A-Za-z_][A-Za-z0-9_]*\\.[A-Za-z_][A-Za-z0-9_]*$"
+      "pattern": "^[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)+$"
     },
     "FullyQualifiedReference": {
       "type": "string",


### PR DESCRIPTION
Fixes #239

Updates the shorthand regex to allow for multiple namespaces, i.e. `schema.table.field`