### PR TITLE
Fix Athena server: make stagingDir optional, add workgroup field

### DIFF
--- a/docs/infrastructure-servers.md
+++ b/docs/infrastructure-servers.md
@@ -72,6 +72,7 @@ If your server is not in the list, please use [custom](#custom-server) and sugge
 | stagingDir | Staging Directory | No       | Amazon Athena automatically stores query results and metadata information for each query that runs in a query result location that you can specify in Amazon S3. |
 | catalog    | Catalog           | No       | Identify the name of the Data Source, also referred to as a Catalog.                                                                                             |
 | regionName | Region Name       | No       | The region your AWS account uses.                                                                                                                                |
+| workgroup  | Workgroup         | No       | The Athena workgroup to use. Workgroups can enforce query result location and other client-side settings via the 'Override client-side settings' option.         |
 
 ### Azure Server
 

--- a/schema/odcs-json-schema-v3.1.0.json
+++ b/schema/odcs-json-schema-v3.1.0.json
@@ -692,10 +692,14 @@
             "type": "string",
             "description": "The region your AWS account uses.",
             "examples": ["eu-west-1"]
+          },
+          "workgroup": {
+            "type": "string",
+            "description": "The Athena workgroup to use. Workgroups can enforce query result location and other client-side settings via the 'Override client-side settings' option.",
+            "examples": ["primary"]
           }
         },
         "required": [
-          "stagingDir",
           "schema"
         ]
       },


### PR DESCRIPTION
## Summary
- Remove `stagingDir` from required fields of `amazon-athena-server` in the JSON schema to match `docs/infrastructure-servers.md` (which already lists it as optional).
- Add a new optional `workgroup` field to the Athena server, enabling setups that use [Athena managed query results](https://docs.aws.amazon.com/athena/latest/ug/managed-results.html) with workgroup-enforced client-side settings.

Fixes #256

## Test plan
- [x] `python3 -c "import json; json.load(open('schema/odcs-json-schema-v3.1.0.json'))"` — schema remains valid JSON
- [ ] Reviewer confirms docs/schema alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)