### PR TITLE
Move Athena schema changes from v3.1.0 to latest schema

### DIFF
--- a/schema/odcs-json-schema-latest.json
+++ b/schema/odcs-json-schema-latest.json
@@ -692,10 +692,14 @@
             "type": "string",
             "description": "The region your AWS account uses.",
             "examples": ["eu-west-1"]
+          },
+          "workgroup": {
+            "type": "string",
+            "description": "The Athena workgroup to use. Workgroups can enforce query result location and other client-side settings via the 'Override client-side settings' option.",
+            "examples": ["primary"]
           }
         },
         "required": [
-          "stagingDir",
           "schema"
         ]
       },

--- a/schema/odcs-json-schema-v3.1.0.json
+++ b/schema/odcs-json-schema-v3.1.0.json
@@ -692,14 +692,10 @@
             "type": "string",
             "description": "The region your AWS account uses.",
             "examples": ["eu-west-1"]
-          },
-          "workgroup": {
-            "type": "string",
-            "description": "The Athena workgroup to use. Workgroups can enforce query result location and other client-side settings via the 'Override client-side settings' option.",
-            "examples": ["primary"]
           }
         },
         "required": [
+          "stagingDir",
           "schema"
         ]
       },


### PR DESCRIPTION
## Summary
- PR #258 modified the released `odcs-json-schema-v3.1.0.json`, but per `schema/README.md` versioned schema files are immutable references for SchemaStore and only `odcs-json-schema-latest.json` should receive ongoing changes.
- Revert the Athena `workgroup` field addition and the `stagingDir`-required removal in `odcs-json-schema-v3.1.0.json`.
- Apply the same changes to `odcs-json-schema-latest.json` instead.

The docs change in `docs/infrastructure-servers.md` from #258 remains untouched.

## Test plan
- [x] `python3 -c "import json; json.load(open('schema/odcs-json-schema-v3.1.0.json')); json.load(open('schema/odcs-json-schema-latest.json'))"` — both schemas remain valid JSON
- [x] Diff confirms v3.1.0 is restored to its pre-#258 state and latest now carries the changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)