### PR TITLE
feat: add encoding to schema elements

### DIFF
--- a/docs/examples/schema/table-column.odcs.yaml
+++ b/docs/examples/schema/table-column.odcs.yaml
@@ -4,10 +4,11 @@ id: 53581432-6c55-4ba2-a65f-72344a91553b
 status: active
 name: my_table
 dataProduct: my_quantum
-apiVersion: v3.0.2
+apiVersion: v3.1.0
 schema:
   - name: tbl
     physicalType: table
+    encoding: UTF-8
     properties:
     - name: rcvr_cntry_code
       businessName: Receiver country code

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -32,6 +32,7 @@ schema:
     logicalType: object
     physicalType: table
     physicalName: tbl_1
+    encoding: UTF-8
     description: Provides core payment metrics
     authoritativeDefinitions:
       - url: https://catalog.data.gov/dataset/air-quality
@@ -166,6 +167,7 @@ schema:
 | Key                                                    | Type   | UX label                     | Required | Description                                                                          |
 |--------------------------------------------------------|--------|------------------------------|----------|--------------------------------------------------------------------------------------|
 | dataGranularityDescription                             | string | Data Granularity             | No       | Granular level of the data in the object. Example would be "Aggregation by country." |
+| encoding                                               | string | Encoding                     | No       | Expected character encoding for the object, especially for file, topic or dataset-like objects. For example, `UTF-8`, `ISO-8859-1`, `ASCII`, or `UTF-16`. |
 
 ### Applicable to Properties
 

--- a/schema/odcs-json-schema-latest.json
+++ b/schema/odcs-json-schema-latest.json
@@ -1650,6 +1650,11 @@
           "description": "Granular level of the data in the object.",
           "examples": ["Aggregation by country"]
         },
+        "encoding": {
+          "type": "string",
+          "description": "The expected character encoding for this schema object, for example UTF-8, ISO-8859-1, ASCII or UTF-16.",
+          "examples": ["UTF-8", "ISO-8859-1", "ASCII", "UTF-16"]
+        },
         "properties": {
           "type": "array",
           "description": "A list of properties for the object.",

--- a/schema/odcs-json-schema-v3.1.0.json
+++ b/schema/odcs-json-schema-v3.1.0.json
@@ -1650,6 +1650,11 @@
           "description": "Granular level of the data in the object.",
           "examples": ["Aggregation by country"]
         },
+        "encoding": {
+          "type": "string",
+          "description": "The expected character encoding for this schema object, for example UTF-8, ISO-8859-1, ASCII or UTF-16.",
+          "examples": ["UTF-8", "ISO-8859-1", "ASCII", "UTF-16"]
+        },
         "properties": {
           "type": "array",
           "description": "A list of properties for the object.",


### PR DESCRIPTION
## Summary
- Add an optional `encoding` field to schema objects (`SchemaObject`), not to the top-level contract
- Document the new field under object-specific schema fields, with use cases like files/topics/datasets
- Add an example using `encoding: UTF-8`

This follows the issue discussion suggesting that encoding should live at the schema/element level rather than at the top-level contract, especially when the element is an object / dataset.

## Validation
- `python3 -m json.tool schema/odcs-json-schema-latest.json`
- `python3 -m json.tool schema/odcs-json-schema-v3.1.0.json`
- `bash src/script/validate-examples.sh`
- `JSON_SCHEMA_VERSION=latest bash src/script/validate-examples.sh`
- Validated a temporary contract using object-level `encoding` against v3.1.0 with `ajv`
- Confirmed property-level `encoding` is rejected, keeping the change scoped to schema objects

Closes #263
