### PR TITLE
chore: add Apache-2.0 / SPDX headers to source files

### DIFF
--- a/.github/workflows/docs-site-deploy.yaml
+++ b/.github/workflows/docs-site-deploy.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 name: docs-site-deploy
 on:
   push:

--- a/.github/workflows/protect-main.yaml
+++ b/.github/workflows/protect-main.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 name: Protect main branch
 
 # Only PRs from `dev` may target `main`. This guards against bypass commits

--- a/.github/workflows/validate-examples.yaml
+++ b/.github/workflows/validate-examples.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 name: validate-examples
 on:
   pull_request:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,11 @@ description: "How you can contribute to the Open Data Contract Standard (ODCS)."
 image: "https://raw.githubusercontent.com/bitol-io/artwork/main/horizontal/color/Bitol_Logo_color.svg"
 ---
 
+<!--
+Copyright 2026 The Bitol Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Contributing to Open Data Contract Standard
 
 Thank you for your interest in contributing to Open Data Contract Standard (ODCS). Please refer to the [TSC contributing guidelines](https://github.com/bitol-io/tsc/blob/main/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ description: "Home of Open Data Contract Standard (ODCS) documentation."
 image: "https://raw.githubusercontent.com/bitol-io/artwork/main/horizontal/color/Bitol_Logo_color.svg"
 ---
 
+<!--
+Copyright 2026 The Bitol Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8149/badge)](https://www.bestpractices.dev/projects/8149)
   <a href="https://github.com/bitol-io/open-data-contract-standard">
     <img alt="Stars" src="https://img.shields.io/github/stars/bitol-io/open-data-contract-standard" /></a>

--- a/building-doc.md
+++ b/building-doc.md
@@ -1,3 +1,8 @@
+<!--
+Copyright 2026 The Bitol Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Automatic documentation builder
 
 Starting with ODCS v2.2.2, the documentation is available through [GitHub.io](https://bitol-io.github.io/open-data-contract-standard). This page explains the process of building the doc.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,11 @@ description: "Details of the Open Data Contract Standard (ODCS). Includes fundam
 image: "https://raw.githubusercontent.com/bitol-io/artwork/main/horizontal/color/Bitol_Logo_color.svg"
 ---
 
+<!--
+Copyright 2026 The Bitol Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Open Data Contract Standard
 
 ## Executive Summary

--- a/docs/authoritative-definitions.md
+++ b/docs/authoritative-definitions.md
@@ -3,6 +3,11 @@ title: "Authoritative Definitions"
 description: "Reference external sources of truth from a data contract."
 ---
 
+<!--
+Copyright 2026 The Bitol Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Authoritative Definitions
 
 Authoritative Definitions are an essential part of the contract. They allow to delegate the definition or authority to a third party system like an enterprise catalog, repository, etc. The structure describing "Authoritative Definitions" is shared between all Bitol standards. This block is available in many sections.

--- a/docs/context.md
+++ b/docs/context.md
@@ -3,6 +3,11 @@ title: "Context"
 description: "AI and semantic context guidance for the data contract."
 ---
 
+<!--
+Copyright 2026 The Bitol Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Context
 
 Added in **ODCS v3.2.0** (RFC-0038). The `context` block provides structured, human- and machine-readable guidance for AI agents, LLMs, BI tools, and semantic layer platforms. It is optional and additive.

--- a/docs/custom-other-properties.md
+++ b/docs/custom-other-properties.md
@@ -3,6 +3,11 @@ title: "Custom & Other Properties"
 description: "This section covers custom properties you may find in a data contract."
 ---
 
+<!--
+Copyright 2026 The Bitol Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Custom & Other Properties
 
 This section covers other properties you may find in a data contract.

--- a/docs/data-quality.md
+++ b/docs/data-quality.md
@@ -3,6 +3,11 @@ title: "Data Quality"
 description: "his section describes data quality rules & parameters."
 ---
 
+<!--
+Copyright 2026 The Bitol Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Data Quality
 
 This section describes data quality rules & parameters. They are tightly linked to the schema described in the previous section.

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,3 +1,8 @@
+<!--
+Copyright 2026 The Bitol Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Examples of Data Contracts
 
 This folder contains example data contracts illustrating each section of the **Open Data Contract Standard**. Most files are excerpts that exercise a single feature; the [full examples](#full-examples) put many features together in a single contract.

--- a/docs/examples/all/full-example.odcs.yaml
+++ b/docs/examples/all/full-example.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # What's this data contract about?
 domain: seller # Domain
 dataProduct: my quantum # Data product name

--- a/docs/examples/all/postgresql-adventureworks-contract.odcs.yaml
+++ b/docs/examples/all/postgresql-adventureworks-contract.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: "1.0.0"
 apiVersion: "v3.0.0"
 id: "6aeafdc1-ed62-4c8f-bf0a-da1061c98cdb"

--- a/docs/examples/authoritative-definitions/authoritative-definitions.odcs.yaml
+++ b/docs/examples/authoritative-definitions/authoritative-definitions.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 kind: DataContract
 id: 9a4b1c2d-3e5f-4a7b-8c9d-1e2f3a4b5c6d

--- a/docs/examples/custom-other-properties/custom-properties.odcs.yaml
+++ b/docs/examples/custom-other-properties/custom-properties.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 kind: DataContract
 id: 4f7a8b9c-1d2e-4f3a-8b5c-6d7e8f9a0b1c

--- a/docs/examples/data-types/all-data-types.odcs.yaml
+++ b/docs/examples/data-types/all-data-types.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 kind: DataContract
 id: 53581432-6c55-4ba2-a65f-72344a91553a

--- a/docs/examples/fundamentals/table-column-description.odcs.yaml
+++ b/docs/examples/fundamentals/table-column-description.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 kind: DataContract
 id: 53581432-6c55-4ba2-a65f-72344a91553a

--- a/docs/examples/pricing/basic-pricing.odcs.yaml
+++ b/docs/examples/pricing/basic-pricing.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 kind: DataContract
 id: 8d9e0f1a-2b3c-4d5e-6f70-8a9b0c1d2e3f

--- a/docs/examples/quality/column-accuracy.odcs.yaml
+++ b/docs/examples/quality/column-accuracy.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 kind: DataContract
 id: 53581432-6c55-4ba2-a65f-72344a91553a

--- a/docs/examples/quality/column-completeness.odcs.yaml
+++ b/docs/examples/quality/column-completeness.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 apiVersion: v3.0.2
 kind: DataContract

--- a/docs/examples/quality/column-custom.odcs.yaml
+++ b/docs/examples/quality/column-custom.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 apiVersion: v3.2.0
 kind: DataContract

--- a/docs/examples/quality/column-validity.odcs.yaml
+++ b/docs/examples/quality/column-validity.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 apiVersion: v3.2.0
 kind: DataContract

--- a/docs/examples/references/relationships.odcs.yaml
+++ b/docs/examples/references/relationships.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 kind: DataContract
 id: 5e9f1c2a-7b6d-4e3f-8a1b-2c3d4e5f6a7b

--- a/docs/examples/roles/service-and-operational-roles.odcs.yaml
+++ b/docs/examples/roles/service-and-operational-roles.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 kind: DataContract
 id: 53581432-6c55-4ba2-a65f-72344a91553a

--- a/docs/examples/schema/all-schema-types.odcs.yaml
+++ b/docs/examples/schema/all-schema-types.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 kind: DataContract
 id: 53581432-6c55-4ba2-a65f-72344a91553a

--- a/docs/examples/schema/enum.odcs.yaml
+++ b/docs/examples/schema/enum.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 kind: DataContract
 id: a3e8e1f9-1c8b-4f2e-9a7d-3c5e7b6a9f12

--- a/docs/examples/schema/kafka-schema.odcs.yaml
+++ b/docs/examples/schema/kafka-schema.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v3.0.2
 kind: DataContract
 id: orders

--- a/docs/examples/schema/kafka-schemaregistry.odcs.yaml
+++ b/docs/examples/schema/kafka-schemaregistry.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v3.0.2
 kind: DataContract
 id: orders

--- a/docs/examples/schema/map.odcs.yaml
+++ b/docs/examples/schema/map.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 kind: DataContract
 id: 7d2c4f6a-9b1e-4d3a-8c5f-1a2b3c4d5e6f

--- a/docs/examples/schema/table-column.odcs.yaml
+++ b/docs/examples/schema/table-column.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 kind: DataContract
 id: 53581432-6c55-4ba2-a65f-72344a91553b

--- a/docs/examples/schema/table-columns-with-partition.odcs.yaml
+++ b/docs/examples/schema/table-columns-with-partition.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 kind: DataContract
 id: 53581432-6c55-4ba2-a65f-72344a91553c

--- a/docs/examples/server/azure-server.odcs.yaml
+++ b/docs/examples/server/azure-server.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 apiVersion: v3.0.2
 kind: DataContract

--- a/docs/examples/server/kafka-server.odcs.yaml
+++ b/docs/examples/server/kafka-server.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 apiVersion: v3.0.2
 kind: DataContract

--- a/docs/examples/sla/database-table-sla.odcs.yaml
+++ b/docs/examples/sla/database-table-sla.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 apiVersion: v3.2.0
 kind: DataContract

--- a/docs/examples/stakeholders/basic-four-dpo.odcs.yaml
+++ b/docs/examples/stakeholders/basic-four-dpo.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 apiVersion: v3.0.2
 kind: DataContract

--- a/docs/examples/support/support-channels.odcs.yaml
+++ b/docs/examples/support/support-channels.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 kind: DataContract
 id: b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e

--- a/docs/examples/tags/tags.odcs.yaml
+++ b/docs/examples/tags/tags.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 kind: DataContract
 id: 6c1a2b3d-4e5f-4789-9abc-def012345678

--- a/docs/examples/team/team.odcs.yaml
+++ b/docs/examples/team/team.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 kind: DataContract
 id: c5d6e7f8-9a0b-4c1d-2e3f-4a5b6c7d8e9f

--- a/docs/fundamentals.md
+++ b/docs/fundamentals.md
@@ -3,6 +3,11 @@ title: "Fundamentals"
 description: "This section contains general information about the contract."
 ---
 
+<!--
+Copyright 2026 The Bitol Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Fundamentals
 
 This section contains general information about the contract. Fundamentals were also called demographics in early versions of ODCS.

--- a/docs/infrastructure-servers.md
+++ b/docs/infrastructure-servers.md
@@ -3,6 +3,11 @@ title: "Infrastructures & Servers"
 description: "This section describes server structures, properties and types."
 ---
 
+<!--
+Copyright 2026 The Bitol Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Infrastructure & Servers
 
 The `servers` element describes where the data protected by this data contract is *physically* located. That metadata helps to know where the data is so that a data consumer can discover the data and a platform engineer can automate access.

--- a/docs/pricing.md
+++ b/docs/pricing.md
@@ -3,6 +3,11 @@ title: "Pricing"
 description: "This section covers pricing when you bill your customer for using this data product."
 ---
 
+<!--
+Copyright 2026 The Bitol Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Pricing
 
 This section covers pricing when you bill your customer for using this data product.

--- a/docs/references.md
+++ b/docs/references.md
@@ -3,6 +3,11 @@ title: "References"
 description: "This section describes how to reference elements within a data contract schema."
 ---
 
+<!--
+Copyright 2026 The Bitol Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # References
 
 This section describes how to reference elements within a data contract schema. References enable you to create relationships between different parts of your data contract. This section is new in ODCS v3.1.0.

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -1,3 +1,8 @@
+<!--
+Copyright 2026 The Bitol Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Articles & Other Resources
 
 ## Articles

--- a/docs/roles.md
+++ b/docs/roles.md
@@ -3,6 +3,11 @@ title: "Roles"
 description: "This section lists the roles that a consumer may need to access the dataset, depending on the type of access they require."
 ---
 
+<!--
+Copyright 2026 The Bitol Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Roles
 
 This section lists the roles that a consumer may need to access the dataset, depending on the type of access they require.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -3,6 +3,11 @@ title: "Schema"
 description: "This section describes the schema of the data contract."
 ---
 
+<!--
+Copyright 2026 The Bitol Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Schema
 
 This section describes the schema of the data contract. It is the support for data quality, which is detailed in the next section. Schema supports both a business representation of your data and a physical implementation. It allows to tie them together.

--- a/docs/service-level-agreement.md
+++ b/docs/service-level-agreement.md
@@ -3,6 +3,11 @@ title: "Service-Level Agreement"
 description: "This section describes the service-level agreements (SLA)."
 ---
 
+<!--
+Copyright 2026 The Bitol Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Service-Level Agreement (SLA)
 
 This section describes the service-level agreements (SLA).

--- a/docs/support-communication-channels.md
+++ b/docs/support-communication-channels.md
@@ -3,6 +3,11 @@ title: "Support & Communication Channels"
 description: "Support and communication channels help consumers find help regarding their use of the data contract."
 ---
 
+<!--
+Copyright 2026 The Bitol Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Support & Communication Channels
 
 Support and communication channels help consumers find help regarding their use of the data contract. They support multiple channels.

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -3,6 +3,11 @@ title: "Tags"
 description: "Lightweight, free-form classification labels attached to elements of a data contract."
 ---
 
+<!--
+Copyright 2026 The Bitol Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Tags
 
 Tags are lightweight, free-form classification labels that can be attached to many elements of a data contract. The structure is shared across the Bitol standards and follows the same shape everywhere it appears.

--- a/docs/team.md
+++ b/docs/team.md
@@ -2,6 +2,11 @@
 title: "Team"
 description: "This section lists team members and the history of their relation with this data contract."
 ---
+
+<!--
+Copyright 2026 The Bitol Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
 # Team
 
 This section lists team members and the history of their relation with this data contract. 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 site_name: Open Data Contract Standard
 site_url: https://bitol-io.github.io/open-data-contract-standard/
 repo_url: https://github.com/bitol-io/open-data-contract-standard

--- a/resources.md
+++ b/resources.md
@@ -1,3 +1,8 @@
+<!--
+Copyright 2026 The Bitol Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Articles & Other Resources
 
 ## Articles

--- a/schema/README.md
+++ b/schema/README.md
@@ -1,3 +1,8 @@
+<!--
+Copyright 2026 The Bitol Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # ODCS JSON Schema — Versioning
 
 This directory holds every published version of the Open Data Contract Standard (ODCS) JSON Schema.

--- a/src/script/README.md
+++ b/src/script/README.md
@@ -1,3 +1,8 @@
+<!--
+Copyright 2026 The Bitol Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Script
 
 ## Building docs

--- a/src/script/build_docs.sh
+++ b/src/script/build_docs.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 echo "Moving top level markdown files into 'docs' folder"
 cat README.md | sed 's/(docs\//(/g' | sed 's/CONTRIBUTING.md/contributing.md/g' > docs/home.md
 cat CHANGELOG.md | sed 's/(docs\//(/g' > docs/changelog.md

--- a/src/script/negative-tests/additional-unknown-property.odcs.yaml
+++ b/src/script/negative-tests/additional-unknown-property.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 apiVersion: v3.2.0
 kind: DataContract

--- a/src/script/negative-tests/enum-duplicate-values.odcs.yaml
+++ b/src/script/negative-tests/enum-duplicate-values.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 apiVersion: v3.2.0
 kind: DataContract

--- a/src/script/negative-tests/enum-empty.odcs.yaml
+++ b/src/script/negative-tests/enum-empty.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 apiVersion: v3.2.0
 kind: DataContract

--- a/src/script/negative-tests/enum-missing-value.odcs.yaml
+++ b/src/script/negative-tests/enum-missing-value.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 apiVersion: v3.2.0
 kind: DataContract

--- a/src/script/negative-tests/invalid-api-version.odcs.yaml
+++ b/src/script/negative-tests/invalid-api-version.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 apiVersion: v4.0.0
 kind: DataContract

--- a/src/script/negative-tests/invalid-kind.odcs.yaml
+++ b/src/script/negative-tests/invalid-kind.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 apiVersion: v3.2.0
 kind: DataModel

--- a/src/script/negative-tests/invalid-quality-dimension.odcs.yaml
+++ b/src/script/negative-tests/invalid-quality-dimension.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 apiVersion: v3.2.0
 kind: DataContract

--- a/src/script/negative-tests/invalid-quality-metric.odcs.yaml
+++ b/src/script/negative-tests/invalid-quality-metric.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 apiVersion: v3.2.0
 kind: DataContract

--- a/src/script/negative-tests/invalid-quality-type.odcs.yaml
+++ b/src/script/negative-tests/invalid-quality-type.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 apiVersion: v3.2.0
 kind: DataContract

--- a/src/script/negative-tests/map-missing-block.odcs.yaml
+++ b/src/script/negative-tests/map-missing-block.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 apiVersion: v3.2.0
 kind: DataContract

--- a/src/script/negative-tests/map-missing-key.odcs.yaml
+++ b/src/script/negative-tests/map-missing-key.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 apiVersion: v3.2.0
 kind: DataContract

--- a/src/script/negative-tests/map-missing-value.odcs.yaml
+++ b/src/script/negative-tests/map-missing-value.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 apiVersion: v3.2.0
 kind: DataContract

--- a/src/script/negative-tests/missing-required-fields.odcs.yaml
+++ b/src/script/negative-tests/missing-required-fields.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 apiVersion: v3.2.0
 kind: DataContract

--- a/src/script/negative-tests/quality-custom-missing-implementation.odcs.yaml
+++ b/src/script/negative-tests/quality-custom-missing-implementation.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 apiVersion: v3.2.0
 kind: DataContract

--- a/src/script/negative-tests/quality-element-field.odcs.yaml
+++ b/src/script/negative-tests/quality-element-field.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 apiVersion: v3.2.0
 kind: DataContract

--- a/src/script/negative-tests/quality-library-missing-metric.odcs.yaml
+++ b/src/script/negative-tests/quality-library-missing-metric.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 apiVersion: v3.2.0
 kind: DataContract

--- a/src/script/negative-tests/quality-multiple-operators.odcs.yaml
+++ b/src/script/negative-tests/quality-multiple-operators.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 apiVersion: v3.2.0
 kind: DataContract

--- a/src/script/negative-tests/quality-mustbebetween-wrong-size.odcs.yaml
+++ b/src/script/negative-tests/quality-mustbebetween-wrong-size.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 apiVersion: v3.2.0
 kind: DataContract

--- a/src/script/negative-tests/quality-sql-missing-query.odcs.yaml
+++ b/src/script/negative-tests/quality-sql-missing-query.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 apiVersion: v3.2.0
 kind: DataContract

--- a/src/script/negative-tests/relationship-property-level-with-from.odcs.yaml
+++ b/src/script/negative-tests/relationship-property-level-with-from.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 apiVersion: v3.2.0
 kind: DataContract

--- a/src/script/negative-tests/relationship-schema-level-missing-from-to.odcs.yaml
+++ b/src/script/negative-tests/relationship-schema-level-missing-from-to.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 apiVersion: v3.2.0
 kind: DataContract

--- a/src/script/negative-tests/schema-property-invalid-logicaltype.odcs.yaml
+++ b/src/script/negative-tests/schema-property-invalid-logicaltype.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 apiVersion: v3.2.0
 kind: DataContract

--- a/src/script/negative-tests/schema-property-missing-name.odcs.yaml
+++ b/src/script/negative-tests/schema-property-missing-name.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 apiVersion: v3.2.0
 kind: DataContract

--- a/src/script/negative-tests/server-invalid-type.odcs.yaml
+++ b/src/script/negative-tests/server-invalid-type.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 apiVersion: v3.2.0
 kind: DataContract

--- a/src/script/negative-tests/server-missing-conditional-fields.odcs.yaml
+++ b/src/script/negative-tests/server-missing-conditional-fields.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 apiVersion: v3.2.0
 kind: DataContract

--- a/src/script/negative-tests/server-missing-required-fields.odcs.yaml
+++ b/src/script/negative-tests/server-missing-required-fields.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 apiVersion: v3.2.0
 kind: DataContract

--- a/src/script/negative-tests/sla-missing-required-value.odcs.yaml
+++ b/src/script/negative-tests/sla-missing-required-value.odcs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1.0.0
 apiVersion: v3.2.0
 kind: DataContract

--- a/src/script/schema-diff.sh
+++ b/src/script/schema-diff.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Script to generate diff between JSON schema files
 # Usage: ./schema-diff.sh [new_schema_file] [old_schema_file]
 # If no arguments provided, it will try to detect the latest and previous schema files

--- a/src/script/validate-examples.sh
+++ b/src/script/validate-examples.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'

--- a/src/script/validate-negative.sh
+++ b/src/script/validate-negative.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'

--- a/vendors.md
+++ b/vendors.md
@@ -1,3 +1,8 @@
+<!--
+Copyright 2026 The Bitol Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Available third-party solutions & support
 
 ## Software vendors & package


### PR DESCRIPTION
Adds a uniform copyright + SPDX header to every project-authored Markdown, YAML, shell, and config file:

\`\`\`
Copyright 2026 The Bitol Contributors
SPDX-License-Identifier: Apache-2.0
\`\`\`

### Form per language
- **Markdown** — HTML comment, placed after YAML front-matter when present (so MkDocs metadata parsing is preserved)
- **YAML / mkdocs / GitHub workflows** — \`#\` comment at top of file
- **Shell scripts** — \`#\` comment after the shebang

### Skipped
- \`schema/*.json\` — JSON has no comment syntax, and the versioned schemas are released artifacts whose bytes shouldn't change retroactively. The repo-level \`LICENSE\` covers them.
- \`LICENSE\`, \`AUTHORS.md\`, \`CHANGELOG.md\`, \`history.md\` — by Apache / LF convention

### Notes
- Wording follows LF norms: *The Bitol Contributors* (vendor-neutral, no per-file company copyrights, no "All rights reserved").
- Two Kafka example YAMLs (\`docs/examples/schema/kafka-schema.odcs.yaml\`, \`kafka-schemaregistry.odcs.yaml\`) were incidentally normalized from CRLF → LF.
- 86 files changed, +358 / −52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)