### PR TITLE
fix: accept .yml extension in FullyQualifiedReference pattern

### DIFF
--- a/schema/odcs-json-schema-latest.json
+++ b/schema/odcs-json-schema-latest.json
@@ -209,7 +209,7 @@
     "FullyQualifiedReference": {
       "type": "string",
       "description": "Fully qualified notation using id fields (section/id/properties/id), optionally prefixed with external file reference",
-      "pattern": "^(?:(?:https?:\\/\\/)?[A-Za-z0-9._\\-\\/]+\\.yaml#)?\\/?[A-Za-z_][A-Za-z0-9_]*\\/[A-Za-z0-9_-]+(?:\\/[A-Za-z_][A-Za-z0-9_]*\\/[A-Za-z0-9_-]+)*$"
+      "pattern": "^(?:(?:https?:\\/\\/)?[A-Za-z0-9._\\-\\/]+\\.ya?ml#)?\\/?[A-Za-z_][A-Za-z0-9_]*\\/[A-Za-z0-9_-]+(?:\\/[A-Za-z_][A-Za-z0-9_]*\\/[A-Za-z0-9_-]+)*$"
     },
     "StableId": {
       "type": "string",


### PR DESCRIPTION
Accepts both `.yaml` and `.yml` extensions in external references (`\.yaml#` → `\.ya?ml#`).

Per the versioning rules in `schema/README.md`, this regex relaxation is applied to **both** schema files that track the active lines, keeping them consistent, plus a changelog entry:
- `odcs-json-schema-latest.json` (bleeding edge)
- `odcs-json-schema-v3.2.0.json` (rolling v3.2.0 minor — receives regex fixes per README §2)
- `schema/README.md` — v3.2.0 snapshot changelog entry (2026-06-23)

The **frozen** `odcs-json-schema-v3.1.0.json` is intentionally left untouched (immutable released line; `.yml` support is a v3.2.0-line enhancement).

Clean reapplication of #220, which had the right intent but also injected a stray leading `r` into the pattern, edited the frozen v3.1.0 schema, and reformatted the whole file. Credit to @FriedrichBu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)