### PR TITLE
fix: use #/ in external shorthand reference example (v3.2.0)

### DIFF
--- a/docs/references.md
+++ b/docs/references.md
@@ -344,7 +344,7 @@ schema:
                 value: "Externally referenced contract (fully qualified)"
 
           # To external contract (shorthand)
-          - to: https://example.com/data-contract-v1.yaml#profiles.user_id
+          - to: https://example.com/data-contract-v1.yaml#/profiles.user_id
             customProperties:
               - property: description
                 value: "Externally referenced contract (shorthand)"


### PR DESCRIPTION
Ports the doc fix from #221 (which was merged into `dev`) onto `dev-v3.2.0`, so the v3.2.0 line carries it too.

Aligns the external shorthand reference example with the fully-qualified example above it (both use `#/`). Credit to @FriedrichBu for the original.

🤖 Generated with [Claude Code](https://claude.com/claude-code)