### PR TITLE
fix: sync .yml relaxation into v3.2.0 rolling schema + changelog

### DIFF
--- a/schema/README.md
+++ b/schema/README.md
@@ -96,6 +96,7 @@ Concise summary of what changed between each retained dated snapshot.
 | Date       | Notes                                                                                                                                                                                                                                       |
 |------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | 2026-04-29 | First v3.2.0 snapshot. `apiVersion` default raised to `v3.2.0`. Adds RFC 0033 (Enum) — new `enum` array on schema properties and new `EnumValue` `$def`. Adds RFC 0030 (Maps) — new `map` value for `logicalType` and companion `map` block. |
+| 2026-06-23 | `FullyQualifiedReference` external-file pattern relaxed to accept the `.yml` extension in addition to `.yaml`.                                                                                                                              |
 
 ## SchemaStore registration
 

--- a/schema/odcs-json-schema-v3.2.0.json
+++ b/schema/odcs-json-schema-v3.2.0.json
@@ -209,7 +209,7 @@
     "FullyQualifiedReference": {
       "type": "string",
       "description": "Fully qualified notation using id fields (section/id/properties/id), optionally prefixed with external file reference",
-      "pattern": "^(?:(?:https?:\\/\\/)?[A-Za-z0-9._\\-\\/]+\\.yaml#)?\\/?[A-Za-z_][A-Za-z0-9_]*\\/[A-Za-z0-9_-]+(?:\\/[A-Za-z_][A-Za-z0-9_]*\\/[A-Za-z0-9_-]+)*$"
+      "pattern": "^(?:(?:https?:\\/\\/)?[A-Za-z0-9._\\-\\/]+\\.ya?ml#)?\\/?[A-Za-z_][A-Za-z0-9_]*\\/[A-Za-z0-9_-]+(?:\\/[A-Za-z_][A-Za-z0-9_]*\\/[A-Za-z0-9_-]+)*$"
     },
     "StableId": {
       "type": "string",


### PR DESCRIPTION
Follow-up to #285. That PR was **squash-merged from a stale revision** (only `odcs-json-schema-latest.json`) because of a force-push/merge race — the amended commit that also updated the rolling `v3.2.0` file and the changelog was dropped.

As a result `dev-v3.2.0` is currently **inconsistent**: `latest.json` accepts `.yml` but `odcs-json-schema-v3.2.0.json` still only accepts `.yaml`. Per `schema/README.md` §2, regex relaxations must roll into the rolling minor file too.

This PR applies the two dropped pieces:
- `odcs-json-schema-v3.2.0.json`: `\.yaml#` → `\.ya?ml#`
- `schema/README.md`: v3.2.0 snapshot changelog entry (2026-06-23)

Frozen `v3.1.0.json` intentionally untouched. No dated snapshot (pre-release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)