### PR TITLE
feat(rfc-0043): physical data encoding on server definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ RFCs targeting v3.2.0 are tracked under [`tsc/rfcs/`](https://github.com/bitol-i
   * New optional `synonyms` array on schema objects and properties, recording alternative names for catalogs, AI/LLM tools, and natural language interfaces.
   * Each `synonyms` entry is an object with a required `synonym` plus optional `id`, `description`, `locale` (BCP 47), `source`, `status`, and `customProperties`.
   * Allowed only on schema objects and properties; non-breaking, as `synonyms` is optional.
+* **Adds** Physical data encoding ([RFC 0043](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0043-physical-data-encoding.md)):
+  * New optional `encoding` string field on server definitions that expose serialized payloads (Azure, Glue, Custom, Kafka, Kinesis, Local, S3, SFTP), declaring the expected character encoding of the data, e.g. `UTF-8`, `ISO-8859-1`, `ASCII`, `UTF-16`.
+  * Free-form string (no enum), default `UTF-8`; documents physical-payload encoding separately from the ODCS document encoding. Non-breaking, as `encoding` is optional.
 * **Changes** to Servers:
   * Add optional Athena Server `workgroup` field and fix `stagingDir` to be optional in schema.
 

--- a/docs/examples/server/s3-server-encoding.odcs.yaml
+++ b/docs/examples/server/s3-server-encoding.odcs.yaml
@@ -1,0 +1,32 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Demonstrates RFC-0043: the optional `encoding` field on server definitions.
+# The same logical schema is exposed through two S3 servers with different
+# physical character encodings.
+
+version: 1.0.0
+apiVersion: v3.2.0
+kind: DataContract
+id: 7b3f0c2e-1d4a-4e6b-9f2a-0a1b2c3d4e5f
+status: active
+servers:
+  - server: modern
+    type: s3
+    location: s3://modern-bucket/customers/*.csv
+    format: csv
+    encoding: UTF-8
+  - server: legacy
+    type: s3
+    location: s3://legacy-bucket/customers/*.csv
+    format: csv
+    encoding: ISO-8859-1
+schema:
+  - name: customers
+    physicalType: table
+    properties:
+      - name: customer_id
+        logicalType: string
+        required: true
+      - name: customer_name
+        logicalType: string

--- a/docs/infrastructure-servers.md
+++ b/docs/infrastructure-servers.md
@@ -84,6 +84,7 @@ If your server is not in the list, please use [custom](#custom-server) and sugge
 | Key       | Type   | UX Label  | Required | Description                                                                                   |
 |-----------|--------|-----------|----------|-----------------------------------------------------------------------------------------------|
 | delimiter | string | Delimiter | No       | Only for format = json. How multiple json documents are delimited within one file             |
+| encoding  | string | Encoding  | No       | Expected character encoding of the payload, e.g. UTF-8, ISO-8859-1, ASCII, UTF-16. Defaults to UTF-8. |
 | format    | string | Format    | Yes      | File format.                                                                                  |
 | location  | string | Location  | Yes      | Fully qualified path to Azure Blob Storage or Azure Data Lake Storage (ADLS), supports globs. |
 
@@ -165,6 +166,7 @@ If your server is not in the list, please use [custom](#custom-server) and sugge
 |----------|--------|----------|----------|------------------------------------------------|
 | account  | string | Account  | Yes      | The AWS Glue account                           |
 | database | string | Database | Yes      | The AWS Glue database name                     |
+| encoding | string | Encoding | No       | Expected character encoding of the payload, e.g. UTF-8, ISO-8859-1, ASCII, UTF-16. Defaults to UTF-8. |
 | format   | string | Format   | No       | The format of the files                        |
 | location | string | Location | No       | The AWS S3 path. Must be in the form of a URL. |
 
@@ -202,6 +204,7 @@ If your server is not in the list, please use [custom](#custom-server) and sugge
 
 | Key    | Type   | UX Label | Required | Description                                |
 | ------ | ------ | -------- | -------- | ------------------------------------------ |
+| encoding | string | Encoding | No       | Expected character encoding of the payload, e.g. UTF-8, ISO-8859-1, ASCII, UTF-16. Defaults to UTF-8. |
 | format | string | Format   | No       | The format of the messages.                |
 | host   | string | Host     | Yes      | The bootstrap server of the kafka cluster. |
 
@@ -209,6 +212,7 @@ If your server is not in the list, please use [custom](#custom-server) and sugge
 
 | Key    | Type   | UX Label | Required | Description                          |
 | ------ | ------ | -------- | -------- | ------------------------------------ |
+| encoding | string | Encoding | No       | Expected character encoding of the payload, e.g. UTF-8, ISO-8859-1, ASCII, UTF-16. Defaults to UTF-8. |
 | format | string | Format   | No       | The format of the record             |
 | region | string | Region   | No       | AWS region.                          |
 | stream | string | Stream   | Yes      | The name of the Kinesis data stream. |
@@ -217,6 +221,7 @@ If your server is not in the list, please use [custom](#custom-server) and sugge
 
 | Key    | Type   | UX Label | Required | Description                                        |
 | ------ | ------ | -------- | -------- | -------------------------------------------------- |
+| encoding | string | Encoding | No       | Expected character encoding of the payload, e.g. UTF-8, ISO-8859-1, ASCII, UTF-16. Defaults to UTF-8. |
 | format | string | Format   | Yes      | The format of the file(s)                          |
 | path   | string | Path     | Yes      | The relative or absolute path to the data file(s). |
 
@@ -282,6 +287,7 @@ If your server is not in the list, please use [custom](#custom-server) and sugge
 | Key         | Type   | UX Label     | Required | Description                                                                       |
 | ----------- | ------ | ------------ | -------- | --------------------------------------------------------------------------------- |
 | delimiter   | string | Delimiter    | No       | Only for format = json. How multiple json documents are delimited within one file |
+| encoding    | string | Encoding     | No       | Expected character encoding of the payload, e.g. UTF-8, ISO-8859-1, ASCII, UTF-16. Defaults to UTF-8. |
 | endpointUrl | string | Endpoint URL | No       | The server endpoint for S3-compatible servers.                                    |
 | format      | string | Format       | No       | File format.                                                                      |
 | location    | string | Location     | Yes      | S3 URL, starting with `s3://`                                                     |
@@ -293,6 +299,7 @@ Secure File Transfer Protocol (SFTP) is a network protocol that enables secure a
 | Key       | Type   | UX Label  | Required | Description                                                                       |
 | --------- | ------ | --------- | -------- | --------------------------------------------------------------------------------- |
 | delimiter | string | Delimiter | No       | Only for format = json. How multiple json documents are delimited within one file |
+| encoding  | string | Encoding  | No       | Expected character encoding of the payload, e.g. UTF-8, ISO-8859-1, ASCII, UTF-16. Defaults to UTF-8. |
 | format    | string | Format    | No       | File format.                                                                      |
 | location  | string | Location  | Yes      | SFTP URL, starting with `sftp://`. The URL should include the port number.        |
 
@@ -363,6 +370,7 @@ Actian Zen (formerly Btrieve, later named Pervasive PSQL until version 13) is an
 | database    | string  | Database          | No       | Name of the database.                                               |
 | dataset     | string  | Dataset           | No       | Name of the dataset.                                                |
 | delimiter   | string  | Delimiter         | No       | Delimiter.                                                          |
+| encoding    | string  | Encoding          | No       | Expected character encoding of the payload, e.g. UTF-8, ISO-8859-1, ASCII, UTF-16. Defaults to UTF-8. |
 | endpointUrl | string  | Endpoint URL      | No       | Server endpoint.                                                    |
 | format      | string  | Format            | No       | File format.                                                        |
 | host        | string  | Host              | No       | Host name or IP address.                                            |

--- a/schema/odcs-json-schema-latest.json
+++ b/schema/odcs-json-schema-latest.json
@@ -782,6 +782,16 @@
             ],
             "description": "File format."
           },
+          "encoding": {
+            "type": "string",
+            "description": "The expected character encoding for data payloads exposed through this server, for example UTF-8, ISO-8859-1, ASCII or UTF-16.",
+            "examples": [
+              "UTF-8",
+              "ISO-8859-1",
+              "ASCII",
+              "UTF-16"
+            ]
+          },
           "delimiter": {
             "type": "string",
             "examples": [
@@ -957,6 +967,16 @@
               "csv",
               "json",
               "delta"
+            ]
+          },
+          "encoding": {
+            "type": "string",
+            "description": "The expected character encoding for data payloads exposed through this server, for example UTF-8, ISO-8859-1, ASCII or UTF-16.",
+            "examples": [
+              "UTF-8",
+              "ISO-8859-1",
+              "ASCII",
+              "UTF-16"
             ]
           }
         },
@@ -1138,6 +1158,16 @@
             "type": "string",
             "description": "File format."
           },
+          "encoding": {
+            "type": "string",
+            "description": "The expected character encoding for data payloads exposed through this server, for example UTF-8, ISO-8859-1, ASCII or UTF-16.",
+            "examples": [
+              "UTF-8",
+              "ISO-8859-1",
+              "ASCII",
+              "UTF-16"
+            ]
+          },
           "host": {
             "type": "string",
             "description": "Host name or IP address."
@@ -1203,6 +1233,16 @@
             "description": "The format of the messages.",
             "examples": ["json", "avro", "protobuf", "xml"],
             "default": "json"
+          },
+          "encoding": {
+            "type": "string",
+            "description": "The expected character encoding for data payloads exposed through this server, for example UTF-8, ISO-8859-1, ASCII or UTF-16.",
+            "examples": [
+              "UTF-8",
+              "ISO-8859-1",
+              "ASCII",
+              "UTF-16"
+            ]
           }
         },
         "required": [
@@ -1229,6 +1269,16 @@
               "avro",
               "protobuf"
             ]
+          },
+          "encoding": {
+            "type": "string",
+            "description": "The expected character encoding for data payloads exposed through this server, for example UTF-8, ISO-8859-1, ASCII or UTF-16.",
+            "examples": [
+              "UTF-8",
+              "ISO-8859-1",
+              "ASCII",
+              "UTF-16"
+            ]
           }
         }
       },
@@ -1252,6 +1302,16 @@
               "parquet",
               "delta",
               "csv"
+            ]
+          },
+          "encoding": {
+            "type": "string",
+            "description": "The expected character encoding for data payloads exposed through this server, for example UTF-8, ISO-8859-1, ASCII or UTF-16.",
+            "examples": [
+              "UTF-8",
+              "ISO-8859-1",
+              "ASCII",
+              "UTF-16"
             ]
           }
         },
@@ -1445,6 +1505,16 @@
             ],
             "description": "File format."
           },
+          "encoding": {
+            "type": "string",
+            "description": "The expected character encoding for data payloads exposed through this server, for example UTF-8, ISO-8859-1, ASCII or UTF-16.",
+            "examples": [
+              "UTF-8",
+              "ISO-8859-1",
+              "ASCII",
+              "UTF-16"
+            ]
+          },
           "delimiter": {
             "type": "string",
             "examples": [
@@ -1480,6 +1550,16 @@
               "csv"
             ],
             "description": "File format."
+          },
+          "encoding": {
+            "type": "string",
+            "description": "The expected character encoding for data payloads exposed through this server, for example UTF-8, ISO-8859-1, ASCII or UTF-16.",
+            "examples": [
+              "UTF-8",
+              "ISO-8859-1",
+              "ASCII",
+              "UTF-16"
+            ]
           },
           "delimiter": {
             "type": "string",

--- a/schema/odcs-json-schema-v3.2.0.json
+++ b/schema/odcs-json-schema-v3.2.0.json
@@ -781,6 +781,16 @@
             ],
             "description": "File format."
           },
+          "encoding": {
+            "type": "string",
+            "description": "The expected character encoding for data payloads exposed through this server, for example UTF-8, ISO-8859-1, ASCII or UTF-16.",
+            "examples": [
+              "UTF-8",
+              "ISO-8859-1",
+              "ASCII",
+              "UTF-16"
+            ]
+          },
           "delimiter": {
             "type": "string",
             "examples": [
@@ -956,6 +966,16 @@
               "csv",
               "json",
               "delta"
+            ]
+          },
+          "encoding": {
+            "type": "string",
+            "description": "The expected character encoding for data payloads exposed through this server, for example UTF-8, ISO-8859-1, ASCII or UTF-16.",
+            "examples": [
+              "UTF-8",
+              "ISO-8859-1",
+              "ASCII",
+              "UTF-16"
             ]
           }
         },
@@ -1137,6 +1157,16 @@
             "type": "string",
             "description": "File format."
           },
+          "encoding": {
+            "type": "string",
+            "description": "The expected character encoding for data payloads exposed through this server, for example UTF-8, ISO-8859-1, ASCII or UTF-16.",
+            "examples": [
+              "UTF-8",
+              "ISO-8859-1",
+              "ASCII",
+              "UTF-16"
+            ]
+          },
           "host": {
             "type": "string",
             "description": "Host name or IP address."
@@ -1202,6 +1232,16 @@
             "description": "The format of the messages.",
             "examples": ["json", "avro", "protobuf", "xml"],
             "default": "json"
+          },
+          "encoding": {
+            "type": "string",
+            "description": "The expected character encoding for data payloads exposed through this server, for example UTF-8, ISO-8859-1, ASCII or UTF-16.",
+            "examples": [
+              "UTF-8",
+              "ISO-8859-1",
+              "ASCII",
+              "UTF-16"
+            ]
           }
         },
         "required": [
@@ -1228,6 +1268,16 @@
               "avro",
               "protobuf"
             ]
+          },
+          "encoding": {
+            "type": "string",
+            "description": "The expected character encoding for data payloads exposed through this server, for example UTF-8, ISO-8859-1, ASCII or UTF-16.",
+            "examples": [
+              "UTF-8",
+              "ISO-8859-1",
+              "ASCII",
+              "UTF-16"
+            ]
           }
         }
       },
@@ -1251,6 +1301,16 @@
               "parquet",
               "delta",
               "csv"
+            ]
+          },
+          "encoding": {
+            "type": "string",
+            "description": "The expected character encoding for data payloads exposed through this server, for example UTF-8, ISO-8859-1, ASCII or UTF-16.",
+            "examples": [
+              "UTF-8",
+              "ISO-8859-1",
+              "ASCII",
+              "UTF-16"
             ]
           }
         },
@@ -1444,6 +1504,16 @@
             ],
             "description": "File format."
           },
+          "encoding": {
+            "type": "string",
+            "description": "The expected character encoding for data payloads exposed through this server, for example UTF-8, ISO-8859-1, ASCII or UTF-16.",
+            "examples": [
+              "UTF-8",
+              "ISO-8859-1",
+              "ASCII",
+              "UTF-16"
+            ]
+          },
           "delimiter": {
             "type": "string",
             "examples": [
@@ -1479,6 +1549,16 @@
               "csv"
             ],
             "description": "File format."
+          },
+          "encoding": {
+            "type": "string",
+            "description": "The expected character encoding for data payloads exposed through this server, for example UTF-8, ISO-8859-1, ASCII or UTF-16.",
+            "examples": [
+              "UTF-8",
+              "ISO-8859-1",
+              "ASCII",
+              "UTF-16"
+            ]
           },
           "delimiter": {
             "type": "string",

--- a/src/script/negative-tests/server-encoding-wrong-type.odcs.yaml
+++ b/src/script/negative-tests/server-encoding-wrong-type.odcs.yaml
@@ -1,0 +1,23 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# RFC-0043 negative test: `encoding` must be a string. Here it is an integer,
+# so the schema MUST reject this contract.
+
+version: 1.0.0
+apiVersion: v3.2.0
+kind: DataContract
+id: 9c2d4e6f-2a1b-4c3d-8e5f-1a2b3c4d5e6f
+status: active
+servers:
+  - server: production
+    type: s3
+    location: s3://my-bucket/customer_export/*.csv
+    format: csv
+    encoding: 65001
+schema:
+  - name: customers
+    physicalType: table
+    properties:
+      - name: customer_id
+        logicalType: string


### PR DESCRIPTION
Implements approved **[RFC-0043 — Physical Data Encoding](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0043-physical-data-encoding.md)** (TSC-approved 2026-06-30) for **ODCS v3.2.0**.

Adds an optional, free-form `encoding` string to the server types that expose serialized payloads — Azure, Glue, Custom, Kafka, Kinesis, Local, S3, SFTP — alongside `format`/`delimiter`. Default `UTF-8`, non-breaking.

**Changes**
- **Schema:** `encoding` added to 8 server defs in both `odcs-json-schema-latest.json` and `odcs-json-schema-v3.2.0.json` (kept in lockstep).
- **Docs:** `encoding` row added to those servers in `infrastructure-servers.md`.
- **Example:** `docs/examples/server/s3-server-encoding.odcs.yaml` — passes `validate-examples.sh`.
- **Negative test:** `server-encoding-wrong-type.odcs.yaml` — schema correctly rejects (`validate-negative.sh`).
- **CHANGELOG** entry under v3.2.0.

Both `validate-examples.sh` and `validate-negative.sh` pass locally (ajv-cli / ajv-formats, draft 2019-09).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Adou6Wv1WCxD3JzmMkewvY