### PR TITLE
feat(rfc-0028): deprecated flag on schema objects and properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ RFCs targeting v3.2.0 are tracked under [`tsc/rfcs/`](https://github.com/bitol-i
 * **Adds** Physical data encoding ([RFC 0043](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0043-physical-data-encoding.md)):
   * New optional `encoding` string field on server definitions that expose serialized payloads (Azure, Glue, Custom, Kafka, Kinesis, Local, S3, SFTP), declaring the expected character encoding of the data, e.g. `UTF-8`, `ISO-8859-1`, `ASCII`, `UTF-16`.
   * Free-form string (no enum), default `UTF-8`; documents physical-payload encoding separately from the ODCS document encoding. Non-breaking, as `encoding` is optional.
+* **Adds** Deprecated flag ([RFC 0028](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0028-deprecated-flag.md), shared with ODPS v1.1.0):
+  * New optional `deprecated` boolean on schema objects and properties (including nested properties), indicating an element is no longer recommended for use.
+  * Defaults to `false`; deprecated elements remain documented and validated for backward compatibility. Non-breaking, as `deprecated` is optional.
 * **Changes** to Servers:
   * Add optional Athena Server `workgroup` field and fix `stagingDir` to be optional in schema.
 

--- a/docs/examples/schema/deprecated.odcs.yaml
+++ b/docs/examples/schema/deprecated.odcs.yaml
@@ -1,0 +1,33 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Demonstrates RFC-0028: the optional `deprecated` boolean on schema objects
+# and properties (including nested properties). Defaults to false.
+
+version: 1.0.0
+apiVersion: v3.2.0
+kind: DataContract
+id: 3e8a1b6c-4d2f-4a90-b1c7-5e9f0a2b3c4d
+status: active
+schema:
+  - name: legacy_orders
+    physicalType: table
+    deprecated: true
+    description: "DEPRECATED: use 'orders' instead. Will be removed in the next major version."
+    properties:
+      - name: order_id
+        logicalType: integer
+        required: true
+      - name: category_id
+        logicalType: integer
+        deprecated: true
+        description: "DEPRECATED: use the nested 'category' object instead."
+      - name: category
+        logicalType: object
+        properties:
+          - name: id
+            logicalType: integer
+          - name: legacy_code
+            logicalType: string
+            deprecated: true
+            description: "DEPRECATED: retained for backward compatibility only."

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -157,6 +157,7 @@ schema:
 | ------------------------ | ------ | ------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | businessName             | string | Business Name             | No       | The business name of the element.                                                                                                                                                          |
 | description              | string | Description               | No       | Description of the element.                                                                                                                                                                |
+| deprecated               | boolean | Deprecated               | No       | Indicates this element is deprecated and should not be used in new implementations. Defaults to `false`. See [Deprecated](#deprecated).                                                    |
 | id                       | string | ID                        | No       | A unique identifier for the element used to create stable, refactor-safe references. Recommended for elements that will be referenced. See [References](./references.md) for more details. |
 | name                     | string | Name                      | Yes      | Name of the element.                                                                                                                                                                       |
 | physicalName             | string | Physical Name             | No       | Physical name.                                                                                                                                                                             |
@@ -478,5 +479,31 @@ schema:
 | synonyms[].customProperties | array  | Custom Properties | No       | Custom properties attached to this synonym. Same structure as the standard `customProperties` block.                                   |
 
 `synonyms` was introduced in ODCS v3.2.0 ([RFC 0041](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0041-synonyms.md)).
+
+[Back to TOC](README.md)
+
+## Deprecated
+
+Any element (a schema object or a property, including nested properties) may set the optional `deprecated` boolean to signal that it is no longer recommended for use. It defaults to `false` when not specified. Deprecated elements remain documented and validated for backward compatibility; implementations MAY warn when they are used. Use the `description` field to point to a replacement and provide migration guidance.
+
+```yaml
+schema:
+  - name: customers
+    logicalType: object
+    properties:
+      - name: email_address
+        logicalType: string
+        deprecated: true
+        description: "DEPRECATED: use 'primary_email' instead. Will be removed in the next major version."
+      - name: primary_email
+        logicalType: string
+        description: "Primary email address for the customer."
+```
+
+| Key          | Type    | UX label   | Required | Description                                                                                          |
+| ------------ | ------- | ---------- | -------- | ---------------------------------------------------------------------------------------------------- |
+| deprecated   | boolean | Deprecated | No       | Indicates this element is deprecated and should not be used in new implementations. Defaults to `false`. |
+
+`deprecated` was introduced in ODCS v3.2.0 ([RFC 0028](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0028-deprecated-flag.md)).
 
 [Back to TOC](README.md)

--- a/schema/odcs-json-schema-latest.json
+++ b/schema/odcs-json-schema-latest.json
@@ -1761,6 +1761,11 @@
           "type": "string",
           "description": "The business name of the element."
         },
+        "deprecated": {
+          "type": "boolean",
+          "description": "Indicates this element is deprecated and should not be used in new implementations. Defaults to false.",
+          "default": false
+        },
         "synonyms": {
           "$ref": "#/$defs/Synonyms"
         },

--- a/schema/odcs-json-schema-v3.2.0.json
+++ b/schema/odcs-json-schema-v3.2.0.json
@@ -1760,6 +1760,11 @@
           "type": "string",
           "description": "The business name of the element."
         },
+        "deprecated": {
+          "type": "boolean",
+          "description": "Indicates this element is deprecated and should not be used in new implementations. Defaults to false.",
+          "default": false
+        },
         "synonyms": {
           "$ref": "#/$defs/Synonyms"
         },

--- a/src/script/negative-tests/deprecated-wrong-type.odcs.yaml
+++ b/src/script/negative-tests/deprecated-wrong-type.odcs.yaml
@@ -1,0 +1,18 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# RFC-0028 negative test: `deprecated` must be a boolean. Here it is a string,
+# so the schema MUST reject this contract.
+
+version: 1.0.0
+apiVersion: v3.2.0
+kind: DataContract
+id: 5f1c7a2d-8b3e-4c6a-9d0f-2e4b6a8c0d1e
+status: active
+schema:
+  - name: customers
+    physicalType: table
+    properties:
+      - name: email_address
+        logicalType: string
+        deprecated: "maybe"


### PR DESCRIPTION
Implements approved **[RFC-0028 — Deprecated flag](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0028-deprecated-flag.md)** (TSC-approved 2026-06-30, shared with ODPS v1.1.0) for **ODCS v3.2.0**.

Adds an optional `deprecated` boolean (default `false`) to `SchemaElement`, which both schema objects and properties (including nested properties) inherit via `allOf` — the same placement pattern as `synonyms`.

**Changes**
- **Schema:** `deprecated` on `SchemaElement` in both `odcs-json-schema-latest.json` and `odcs-json-schema-v3.2.0.json` (lockstep).
- **Docs:** `deprecated` row in the "Applicable to Elements" table + a `## Deprecated` section in `schema.md`.
- **Example:** `docs/examples/schema/deprecated.odcs.yaml` — passes `validate-examples.sh`.
- **Negative test:** `deprecated-wrong-type.odcs.yaml` — schema rejects a non-boolean (`validate-negative.sh`).
- **CHANGELOG** entry under v3.2.0.

Both validation scripts pass locally (ajv-cli / ajv-formats, draft 2019-09).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Adou6Wv1WCxD3JzmMkewvY