### PR TITLE
chore: renumber deprecated-flag RFC 0028 → 0051

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ RFCs targeting v3.2.0 are tracked under [`tsc/rfcs/`](https://github.com/bitol-i
 * **Adds** Physical data encoding ([RFC 0043](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0043-physical-data-encoding.md)):
   * New optional `encoding` string field on server definitions that expose serialized payloads (Azure, Glue, Custom, Kafka, Kinesis, Local, S3, SFTP), declaring the expected character encoding of the data, e.g. `UTF-8`, `ISO-8859-1`, `ASCII`, `UTF-16`.
   * Free-form string (no enum), default `UTF-8`; documents physical-payload encoding separately from the ODCS document encoding. Non-breaking, as `encoding` is optional.
-* **Adds** Deprecated flag ([RFC 0028](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0028-deprecated-flag.md), shared with ODPS v1.1.0):
+* **Adds** Deprecated flag ([RFC 0051](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0051-deprecated-flag.md), shared with ODPS v1.1.0):
   * New optional `deprecated` boolean on schema objects and properties (including nested properties), indicating an element is no longer recommended for use.
   * Defaults to `false`; deprecated elements remain documented and validated for backward compatibility. Non-breaking, as `deprecated` is optional.
 * **Adds** Vendor attribution for custom properties ([RFC 0035](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0035-extensions.md), shared with ODPS v1.1.0 and OORS v1.0.0):

--- a/docs/examples/schema/deprecated.odcs.yaml
+++ b/docs/examples/schema/deprecated.odcs.yaml
@@ -1,7 +1,7 @@
 # Copyright 2026 The Bitol Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-# Demonstrates RFC-0028: the optional `deprecated` boolean on schema objects
+# Demonstrates RFC-0051: the optional `deprecated` boolean on schema objects
 # and properties (including nested properties). Defaults to false.
 
 version: 1.0.0

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -504,6 +504,6 @@ schema:
 | ------------ | ------- | ---------- | -------- | ---------------------------------------------------------------------------------------------------- |
 | deprecated   | boolean | Deprecated | No       | Indicates this element is deprecated and should not be used in new implementations. Defaults to `false`. |
 
-`deprecated` was introduced in ODCS v3.2.0 ([RFC 0028](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0028-deprecated-flag.md)).
+`deprecated` was introduced in ODCS v3.2.0 ([RFC 0051](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0051-deprecated-flag.md)).
 
 [Back to TOC](README.md)

--- a/src/script/negative-tests/deprecated-wrong-type.odcs.yaml
+++ b/src/script/negative-tests/deprecated-wrong-type.odcs.yaml
@@ -1,7 +1,7 @@
 # Copyright 2026 The Bitol Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-# RFC-0028 negative test: `deprecated` must be a boolean. Here it is a string,
+# RFC-0051 negative test: `deprecated` must be a boolean. Here it is a string,
 # so the schema MUST reject this contract.
 
 version: 1.0.0


### PR DESCRIPTION
RFC number 0028 was used twice in bitol-io/tsc — the earlier **Permalink** RFC and the later **Deprecated flag** RFC. The Deprecated flag RFC has been renumbered to **0051** (Permalink keeps 0028, having the earlier claim).

This updates ODCS references accordingly:
- `CHANGELOG.md` — RFC link 0028 → 0051
- `docs/schema.md` — RFC link 0028 → 0051
- `docs/examples/schema/deprecated.odcs.yaml` — comment RFC-0028 → RFC-0051
- `src/script/negative-tests/deprecated-wrong-type.odcs.yaml` — comment RFC-0028 → RFC-0051

The old tsc URLs (`…/0028-deprecated-flag.md`) now 404 after the rename; these point to `…/0051-deprecated-flag.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)