### PR TITLE
feat(rfc-0042): vector logicalType for embeddings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ RFCs targeting v3.2.0 are tracked under [`tsc/rfcs/`](https://github.com/bitol-i
 * **Adds** Vendor attribution for custom properties ([RFC 0035](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0035-extensions.md), shared with ODPS v1.1.0 and OORS v1.0.0):
   * New optional `vendor` string on `customProperties` items, associating a custom property with a specific vendor, provider, or external system.
   * SHOULD be a stable, lowercase identifier (`^[a-z0-9][a-z0-9-]*$`); not enforced, and tools MUST preserve unknown vendor values. Non-breaking, as `vendor` is optional.
+* **Adds** Vector type ([RFC 0042](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0042-vector-type.md)):
+  * New `vector` value for `logicalType`, describing a fixed-dimension dense numeric array for embeddings and similarity search.
+  * Dedicated `logicalTypeOptions` for `vector`: required `dimensions` (positive integer) plus optional `elementType`, `distanceMetric`, `normalized`, `embeddingModel`, and `embeddingModelVersion`.
+  * Non-breaking: `vector` is a new optional `logicalType` value.
 * **Changes** to Servers:
   * Add optional Athena Server `workgroup` field and fix `stagingDir` to be optional in schema.
 

--- a/docs/examples/schema/vector.odcs.yaml
+++ b/docs/examples/schema/vector.odcs.yaml
@@ -1,0 +1,39 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Demonstrates RFC-0042: the `vector` logicalType and its logicalTypeOptions
+# (dimensions required; elementType, distanceMetric, normalized, embeddingModel,
+# embeddingModelVersion optional).
+
+version: 1.0.0
+apiVersion: v3.2.0
+kind: DataContract
+id: 8c1d4e7f-2a3b-4c5d-9e0f-1a2b3c4d5e6f
+status: active
+schema:
+  - name: tickets
+    physicalName: ticket_embeddings
+    properties:
+      - name: ticket_id
+        logicalType: string
+        primaryKey: true
+        required: true
+      - name: body
+        logicalType: string
+      - name: body_embedding
+        logicalType: vector
+        physicalType: vector(1536)
+        required: true
+        logicalTypeOptions:
+          dimensions: 1536
+          elementType: float32
+          distanceMetric: cosine
+          normalized: true
+          embeddingModel: openai/text-embedding-3-small
+          embeddingModelVersion: "2024-01-25"
+      - name: body_embedding_int8
+        logicalType: vector
+        logicalTypeOptions:
+          dimensions: 1536
+          elementType: int8
+          distanceMetric: cosine

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -162,7 +162,7 @@ schema:
 | name                     | string | Name                      | Yes      | Name of the element.                                                                                                                                                                       |
 | physicalName             | string | Physical Name             | No       | Physical name.                                                                                                                                                                             |
 | physicalType             | string | Physical Type             | No       | The physical element data type in the data source. For objects: `table`, `view`, `topic`, `file`. For properties: `VARCHAR(2)`, `DOUBLE`, `INT`, etc.                                      |
-| logicalType              | string | Logical Type              | No       | The logical data type of the element. One of `string`, `date`, `timestamp`, `time`, `number`, `integer`, `object`, `array`, `boolean`, or `map`. At the object level this is typically `object` (or `array` for an array of objects); the data-type keywords above apply to properties. |
+| logicalType              | string | Logical Type              | No       | The logical data type of the element. One of `string`, `date`, `timestamp`, `time`, `number`, `integer`, `object`, `array`, `boolean`, `map`, or `vector`. At the object level this is typically `object` (or `array` for an array of objects); the data-type keywords above apply to properties. |
 | quality                  | array  | Quality                   | No       | List of data quality attributes.                                                                                                                                                           |
 | synonyms                 | array  | Synonyms                  | No       | A list of alternative names for the element (object or property), helping catalogs, AI/LLM tools, and natural language interfaces resolve business vocabulary to the underlying object. See [Synonyms](#synonyms).                       |
 | authoritativeDefinitions | array  | Authoritative Definitions | No       | List of links to sources that provide more details on the element; examples would be a link to privacy statement, terms and conditions, license agreements, data catalog, or another tool. |
@@ -232,6 +232,12 @@ Additional metadata options to more accurately define the data type.
 | string              | maxLength        | integer | Maximum Length     | No       | Maximum length of the string.                                                                                                                                                                                                                                      |
 | string              | minLength        | integer | Minimum Length     | No       | Minimum length of the string.                                                                                                                                                                                                                                      |
 | string              | pattern          | string  | Pattern            | No       | Regular expression pattern to define valid value. Follows regular expression syntax from ECMA-262 (<https://262.ecma-international.org/5.1/#sec-15.10.1>).                                                                                                         |
+| vector              | dimensions       | integer | Dimensions         | Yes      | The fixed length of the vector. Positive integer. Examples: `384`, `768`, `1024`, `1536`, `3072`. See [Vectors](#vectors).                                                                                                                                        |
+| vector              | elementType      | string  | Element Type       | No       | Numeric type of each element. One of `bfloat16`, `binary`, `float16`, `float32` (default), `float64`, `int8`, `uint8`. `binary` means each element is one bit (binary-quantized vectors).                                                                          |
+| vector              | distanceMetric   | string  | Distance Metric    | No       | Intended similarity metric. One of `cosine`, `dotProduct`, `euclidean`, `hamming`, `manhattan`. Advisory — the physical index may differ.                                                                                                                          |
+| vector              | embeddingModel   | string  | Embedding Model    | No       | Identifier of the model used to produce the vectors (e.g., `openai/text-embedding-3-small`, `cohere/embed-english-v3.0`).                                                                                                                                          |
+| vector              | embeddingModelVersion | string | Embedding Model Version | No   | Version or revision of the embedding model, when the model identifier does not already carry one.                                                                                                                                                                 |
+| vector              | normalized       | boolean | Normalized         | No       | `true` if vectors are L2-normalized before storage, which makes `cosine` and `dotProduct` equivalent. Default `false`.                                                                                                                                            |
 
 ### Expressing Date / Datetime / Timezone information
 
@@ -376,6 +382,45 @@ schema:
 | map.value | object | Value    | Yes                         | Definition of the map's value. Same shape as any property definition; supports nested `properties` (for objects), `items` (for arrays), `enum`, etc. |
 
 `logicalType: map` was introduced in ODCS v3.2.0 ([RFC 0030](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0030-maps.md)).
+
+## Vectors
+
+A property can declare `logicalType: vector` to describe a fixed-dimension dense numeric array used for embeddings and similarity search (RAG, semantic matching). The shape is captured with `logicalTypeOptions`: `dimensions` (required), and the optional `elementType`, `distanceMetric`, `normalized`, `embeddingModel`, and `embeddingModelVersion`. The outer `physicalType` still carries the target system's native column syntax (e.g. `vector(1536)`, `VECTOR(FLOAT, 1536)`).
+
+### Examples
+
+**Minimal — a single embedding column:**
+
+```yaml
+schema:
+  - name: products
+    properties:
+      - name: description_embedding
+        logicalType: vector
+        required: true
+        logicalTypeOptions:
+          dimensions: 1536
+```
+
+**Detailed — a normalized OpenAI embedding with cosine similarity:**
+
+```yaml
+- name: body_embedding
+  logicalType: vector
+  physicalType: vector(1536)
+  required: true
+  logicalTypeOptions:
+    dimensions: 1536
+    elementType: float32
+    distanceMetric: cosine
+    normalized: true
+    embeddingModel: openai/text-embedding-3-small
+    embeddingModelVersion: "2024-01-25"
+```
+
+`dimensions` is required whenever `logicalType: vector`. See [Logical Type Options](#logical-type-options) for the full list of options.
+
+`logicalType: vector` was introduced in ODCS v3.2.0 ([RFC 0042](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0042-vector-type.md)).
 
 ## Enumerations
 

--- a/schema/odcs-json-schema-latest.json
+++ b/schema/odcs-json-schema-latest.json
@@ -1842,7 +1842,7 @@
         "logicalType": {
           "type": "string",
           "description": "The logical element data type.",
-          "enum": ["string", "date", "timestamp", "time", "number", "integer", "object", "array", "boolean", "map"]
+          "enum": ["string", "date", "timestamp", "time", "number", "integer", "object", "array", "boolean", "map", "vector"]
         },
         "logicalTypeOptions": {
           "type": "object",
@@ -2294,6 +2294,57 @@
               }
             },
             "required": ["map"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "logicalType": {
+                "const": "vector"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "logicalTypeOptions": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "dimensions": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "The fixed length of the vector. Positive integer (only applicable when `logicalType: vector`). See RFC 0042.",
+                    "examples": [384, 768, 1024, 1536, 3072]
+                  },
+                  "elementType": {
+                    "type": "string",
+                    "enum": ["bfloat16", "binary", "float16", "float32", "float64", "int8", "uint8"],
+                    "default": "float32",
+                    "description": "Numeric type of each vector element. `binary` means each element is one bit (binary-quantized vectors)."
+                  },
+                  "distanceMetric": {
+                    "type": "string",
+                    "enum": ["cosine", "dotProduct", "euclidean", "hamming", "manhattan"],
+                    "description": "Intended similarity metric. Advisory \u2014 the physical index may differ."
+                  },
+                  "embeddingModel": {
+                    "type": "string",
+                    "description": "Identifier of the model used to produce the vectors.",
+                    "examples": ["openai/text-embedding-3-small", "cohere/embed-english-v3.0"]
+                  },
+                  "embeddingModelVersion": {
+                    "type": "string",
+                    "description": "Version or revision of the embedding model, when the model identifier does not already carry one."
+                  },
+                  "normalized": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "True if vectors are L2-normalized before storage, which makes cosine and dotProduct equivalent."
+                  }
+                },
+                "required": ["dimensions"]
+              }
+            }
           }
         }
       ],

--- a/schema/odcs-json-schema-v3.2.0.json
+++ b/schema/odcs-json-schema-v3.2.0.json
@@ -1841,7 +1841,7 @@
         "logicalType": {
           "type": "string",
           "description": "The logical element data type.",
-          "enum": ["string", "date", "timestamp", "time", "number", "integer", "object", "array", "boolean", "map"]
+          "enum": ["string", "date", "timestamp", "time", "number", "integer", "object", "array", "boolean", "map", "vector"]
         },
         "logicalTypeOptions": {
           "type": "object",
@@ -2293,6 +2293,57 @@
               }
             },
             "required": ["map"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "logicalType": {
+                "const": "vector"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "logicalTypeOptions": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "dimensions": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "The fixed length of the vector. Positive integer (only applicable when `logicalType: vector`). See RFC 0042.",
+                    "examples": [384, 768, 1024, 1536, 3072]
+                  },
+                  "elementType": {
+                    "type": "string",
+                    "enum": ["bfloat16", "binary", "float16", "float32", "float64", "int8", "uint8"],
+                    "default": "float32",
+                    "description": "Numeric type of each vector element. `binary` means each element is one bit (binary-quantized vectors)."
+                  },
+                  "distanceMetric": {
+                    "type": "string",
+                    "enum": ["cosine", "dotProduct", "euclidean", "hamming", "manhattan"],
+                    "description": "Intended similarity metric. Advisory \u2014 the physical index may differ."
+                  },
+                  "embeddingModel": {
+                    "type": "string",
+                    "description": "Identifier of the model used to produce the vectors.",
+                    "examples": ["openai/text-embedding-3-small", "cohere/embed-english-v3.0"]
+                  },
+                  "embeddingModelVersion": {
+                    "type": "string",
+                    "description": "Version or revision of the embedding model, when the model identifier does not already carry one."
+                  },
+                  "normalized": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "True if vectors are L2-normalized before storage, which makes cosine and dotProduct equivalent."
+                  }
+                },
+                "required": ["dimensions"]
+              }
+            }
           }
         }
       ],

--- a/src/script/negative-tests/vector-missing-dimensions.odcs.yaml
+++ b/src/script/negative-tests/vector-missing-dimensions.odcs.yaml
@@ -1,0 +1,20 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# RFC-0042 negative test: `dimensions` is required whenever logicalType is
+# vector. Here it is omitted, so the schema MUST reject this contract.
+
+version: 1.0.0
+apiVersion: v3.2.0
+kind: DataContract
+id: 9d2e5f8a-3b4c-4d6e-8f1a-2b3c4d5e6f7a
+status: active
+schema:
+  - name: products
+    physicalType: table
+    properties:
+      - name: description_embedding
+        logicalType: vector
+        logicalTypeOptions:
+          elementType: float32
+          distanceMetric: cosine


### PR DESCRIPTION
Implements approved **[RFC-0042 — Vector Type](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0042-vector-type.md)** (TSC-approved 2026-06-30) for **ODCS v3.2.0**.

Adds a `vector` value to the `logicalType` enum plus a conditional `logicalTypeOptions` block for embeddings / similarity search.

Field names are the ones the TSC ratified at approval: **`dimensions`** (over `size`/`numDimensions`/`dim`) and **`elementType`** (over `physicalType`).

**Changes**
- **Schema:** `vector` enum value + an `if logicalType==vector then logicalTypeOptions{…}` block in both `odcs-json-schema-latest.json` and `odcs-json-schema-v3.2.0.json` (lockstep). `dimensions` (positive integer) is **required** when `logicalType: vector`; `elementType`, `distanceMetric`, `normalized`, `embeddingModel`, `embeddingModelVersion` optional.
- **Docs:** `vector` rows in the Logical Type Options table + a `## Vectors` section in `schema.md`.
- **Example:** `docs/examples/schema/vector.odcs.yaml` — passes `validate-examples.sh`.
- **Negative test:** `vector-missing-dimensions.odcs.yaml` — schema rejects (`missingProperty: dimensions`), confirmed via `validate-negative.sh`.
- **CHANGELOG** entry under v3.2.0.

Both validation scripts pass locally (ajv-cli / ajv-formats, draft 2019-09).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Adou6Wv1WCxD3JzmMkewvY