### PR TITLE
feat(rfc-0045): hana server type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ RFCs targeting v3.2.0 are tracked under [`tsc/rfcs/`](https://github.com/bitol-i
   * New `vector` value for `logicalType`, describing a fixed-dimension dense numeric array for embeddings and similarity search.
   * Dedicated `logicalTypeOptions` for `vector`: required `dimensions` (positive integer) plus optional `elementType`, `distanceMetric`, `normalized`, `embeddingModel`, and `embeddingModelVersion`.
   * Non-breaking: `vector` is a new optional `logicalType` value.
+* **Adds** SAP HANA server type ([RFC 0045](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0045-hana-server-type.md)):
+  * New `hana` server `type` for SAP HANA, with required `host` plus optional `port`, `database` (tenant), and `schema`.
+  * Non-breaking: adds a new optional server type.
 * **Changes** to Servers:
   * Add optional Athena Server `workgroup` field and fix `stagingDir` to be optional in schema.
 

--- a/docs/examples/server/hana-server.odcs.yaml
+++ b/docs/examples/server/hana-server.odcs.yaml
@@ -1,0 +1,24 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Demonstrates RFC-0045: the `hana` server type for SAP HANA.
+
+version: 1.0.0
+apiVersion: v3.2.0
+kind: DataContract
+id: 5d8b2a1c-7e3f-4a6d-9b0c-1e2f3a4b5c6d
+status: active
+servers:
+  - server: prod
+    type: hana
+    host: hana.acme.com
+    port: 30015
+    database: HXE
+    schema: SALES
+schema:
+  - name: sales
+    physicalType: table
+    properties:
+      - name: sale_id
+        logicalType: string
+        required: true

--- a/docs/infrastructure-servers.md
+++ b/docs/infrastructure-servers.md
@@ -292,6 +292,17 @@ If your server is not in the list, please use [custom](#custom-server) and sugge
 | format      | string | Format       | No       | File format.                                                                                          |
 | location    | string | Location     | Yes      | S3 URL, starting with `s3://`                                                                         |
 
+### SAP HANA
+
+[SAP HANA](https://www.sap.com/products/technology-platform/hana.html) is an in-memory, column-oriented relational database used as an enterprise data platform.
+
+| Key      | Type    | UX Label | Required | Description                    |
+| -------- | ------- | -------- | -------- | ------------------------------ |
+| host     | string  | Host     | Yes      | Host of the HANA server.       |
+| port     | integer | Port     | No       | Port of the HANA server.       |
+| database | string  | Database | No       | Name of the database (tenant). |
+| schema   | string  | Schema   | No       | Name of the schema.            |
+
 ### SFTP Server
 
 Secure File Transfer Protocol (SFTP) is a network protocol that enables secure and encrypted file transfers between a client and a server.

--- a/schema/odcs-json-schema-latest.json
+++ b/schema/odcs-json-schema-latest.json
@@ -233,7 +233,7 @@
           "description": "Type of the server.",
           "enum": [
             "api", "athena", "azure", "bigquery", "clickhouse", "databricks", "denodo", "dremio",
-            "duckdb", "glue", "cloudsql", "db2", "hive", "impala", "informix", "kafka", "kinesis", "local",
+            "duckdb", "glue", "hana", "cloudsql", "db2", "hive", "impala", "informix", "kafka", "kinesis", "local",
             "mysql", "oracle", "postgresql", "postgres", "presto", "pubsub",
             "redshift", "s3", "sftp", "snowflake", "sqlserver", "synapse", "trino", "vertica", "zen", "custom"
           ]
@@ -543,6 +543,19 @@
           },
           "then": {
             "$ref": "#/$defs/ServerSource/OracleServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "hana"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/HanaServer"
           }
         },
         {
@@ -1401,6 +1414,31 @@
           "port",
           "database",
           "schema"
+        ]
+      },
+      "HanaServer": {
+        "type": "object",
+        "title": "HanaServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "Host of the HANA server."
+          },
+          "port": {
+            "type": "integer",
+            "description": "Port of the HANA server."
+          },
+          "database": {
+            "type": "string",
+            "description": "Name of the database (tenant)."
+          },
+          "schema": {
+            "type": "string",
+            "description": "Name of the schema."
+          }
+        },
+        "required": [
+          "host"
         ]
       },
       "PrestoServer": {

--- a/schema/odcs-json-schema-v3.2.0.json
+++ b/schema/odcs-json-schema-v3.2.0.json
@@ -232,7 +232,7 @@
           "description": "Type of the server.",
           "enum": [
             "api", "athena", "azure", "bigquery", "clickhouse", "databricks", "denodo", "dremio",
-            "duckdb", "glue", "cloudsql", "db2", "hive", "impala", "informix", "kafka", "kinesis", "local",
+            "duckdb", "glue", "hana", "cloudsql", "db2", "hive", "impala", "informix", "kafka", "kinesis", "local",
             "mysql", "oracle", "postgresql", "postgres", "presto", "pubsub",
             "redshift", "s3", "sftp", "snowflake", "sqlserver", "synapse", "trino", "vertica", "zen", "custom"
           ]
@@ -542,6 +542,19 @@
           },
           "then": {
             "$ref": "#/$defs/ServerSource/OracleServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "hana"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/HanaServer"
           }
         },
         {
@@ -1400,6 +1413,31 @@
           "port",
           "database",
           "schema"
+        ]
+      },
+      "HanaServer": {
+        "type": "object",
+        "title": "HanaServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "Host of the HANA server."
+          },
+          "port": {
+            "type": "integer",
+            "description": "Port of the HANA server."
+          },
+          "database": {
+            "type": "string",
+            "description": "Name of the database (tenant)."
+          },
+          "schema": {
+            "type": "string",
+            "description": "Name of the schema."
+          }
+        },
+        "required": [
+          "host"
         ]
       },
       "PrestoServer": {

--- a/src/script/negative-tests/hana-missing-host.odcs.yaml
+++ b/src/script/negative-tests/hana-missing-host.odcs.yaml
@@ -1,0 +1,19 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# RFC-0045 negative test: a `hana` server requires `host`. Here it is omitted,
+# so the schema MUST reject this contract.
+
+version: 1.0.0
+apiVersion: v3.2.0
+kind: DataContract
+id: 6e9c3b2d-8f4a-4b7e-9c1d-2f3a4b5c6d7e
+status: active
+servers:
+  - server: prod
+    type: hana
+    port: 30015
+    database: HXE
+schema:
+  - name: sales
+    physicalType: table


### PR DESCRIPTION
Implements approved **[RFC-0045 — HANA server type](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0045-hana-server-type.md)** (TSC-approved 2026-06-30) for **ODCS v3.2.0**.

Adds `hana` as a server `type` for SAP HANA: required `host` plus optional `port`, `database` (tenant), `schema`.

**Changes**
- **Schema:** `hana` enum value, a `HanaServer` ServerSource def, and the `type`→`$ref` mapping in both `odcs-json-schema-latest.json` and `odcs-json-schema-v3.2.0.json` (lockstep). Only `host` required.
- **Docs:** SAP HANA section in `infrastructure-servers.md`.
- **Example:** `docs/examples/server/hana-server.odcs.yaml` — passes `validate-examples.sh`.
- **Negative test:** `hana-missing-host.odcs.yaml` — schema rejects (`HanaServer/required`, missing `host`), confirmed via `validate-negative.sh`.
- **CHANGELOG** entry under v3.2.0.

**Design note:** the RFC lists `port` as "number"; implemented as `integer` to match every other server type (a port is an integer).

Both validation scripts pass locally (ajv-cli / ajv-formats, draft 2019-09).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Adou6Wv1WCxD3JzmMkewvY