### PR TITLE
feat(rfc-0050): Variables — ${VAR_NAME} interpolation with POSIX defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,11 @@ RFCs targeting v3.2.0 are tracked under [`tsc/rfcs/`](https://github.com/bitol-i
 * **Adds** SLA custom properties and authoritative definitions ([RFC 0046](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0046-sla-custom-properties-and-authoritative-definitions.md)):
   * Each `slaProperties[]` entry may now carry optional `customProperties` and `authoritativeDefinitions`, consistent with other ODCS objects.
   * Non-breaking: both fields are optional.
+* **Adds** Variables ([RFC 0050](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0050-variables.md), shared with ODPS v1.1.0 and OORS v1.0.0):
+  * Any string value in a contract MAY contain `${VAR_NAME}` references, resolved at runtime by tooling, keeping secrets and environment-specific values (hostnames, bucket paths, credentials) out of the document itself.
+  * The POSIX `${VAR_NAME:-default}` form supplies an inline default, used when the variable is unset or empty.
+  * Tools MUST resolve references before using a value, SHOULD error on unresolvable references (never silently substitute an empty string), and MUST preserve unresolved tokens verbatim when serializing back to YAML.
+  * Non-breaking: no new section or field is added to the standard; interpolation applies to string values only.
 * **Changes** to Servers:
   * Add optional Athena Server `workgroup` field and fix `stagingDir` to be optional in schema.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,7 @@ For more details, see the sections below:
 12. [Custom & Other Properties](./custom-other-properties.md)
 13. [Authoritative Definitions](./authoritative-definitions.md)
 14. [Tags](./tags.md)
+15. [Variables](./variables.md)
 
 ## Notes
 

--- a/docs/examples/fundamentals/variables.odcs.yaml
+++ b/docs/examples/fundamentals/variables.odcs.yaml
@@ -1,0 +1,35 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# RFC-0050 example: any string value MAY contain ${VAR_NAME} references,
+# resolved at runtime by tooling. The POSIX ${VAR_NAME:-default} form supplies
+# an inline default used when the variable is unset or empty.
+
+version: 1.0.0
+apiVersion: v3.2.0
+kind: DataContract
+id: 4c1cbb2a-1c86-4e0e-8f0e-6d7c9b1a5e42
+status: active
+name: orders
+
+servers:
+  - server: prod_db
+    environment: prod
+    type: postgresql
+    host: ${DB_HOST}
+    port: 5432
+    database: ${DB_NAME:-orders}
+    schema: ${DB_SCHEMA:-public}
+
+schema:
+  - name: orders
+    physicalType: table
+    properties:
+      - name: order_id
+        logicalType: string
+        physicalType: varchar(36)
+    quality:
+      - type: sql
+        query: "SELECT COUNT(*) FROM ${TARGET_TABLE} WHERE created_at > ${CUTOFF_DATE}"
+        mustBe: 0
+        description: Variable references are valid in any string value, including as substrings.

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -1,0 +1,59 @@
+---
+title: "Variables"
+description: "Variable interpolation in ODCS: keep secrets and environment-specific values out of the data contract with ${VAR_NAME} references resolved at runtime by tooling."
+---
+
+<!--
+Copyright 2026 The Bitol Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Variables
+
+Any string value in a data contract MAY contain one or more variable references of the form `${VAR_NAME}`, resolved at runtime by tooling ([RFC 0050](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0050-variables.md), shared with ODPS and OORS). This keeps secrets and environment-specific values — hostnames, bucket paths, credentials — out of the contract itself, so the same contract works across environments and is safe to store in version control.
+
+References MAY appear as a whole value or as a substring. A reference MAY carry an inline default using the POSIX `${VAR_NAME:-default}` form: the text between `:-` and the closing `}` is used verbatim when the variable is unset or empty.
+
+`VAR_NAME` is an identifier chosen by the contract author. Resolution is intentionally left to tooling; common sources include OS environment variables, `.env` files, secret managers, and CI/CD pipeline variables.
+
+## Example
+
+```yaml
+servers:
+  - server: prod_db
+    environment: prod
+    type: postgresql
+    host: ${DB_HOST}
+    port: 5432
+    database: ${DB_NAME:-orders}
+    schema: ${DB_SCHEMA:-public}
+```
+
+A variable reference is valid in any string value, not just `servers`, and MAY appear as a substring of a larger value — for example in a quality rule query:
+
+```yaml
+quality:
+  - type: sql
+    query: "SELECT COUNT(*) FROM ${TARGET_TABLE} WHERE created_at > ${CUTOFF_DATE}"
+```
+
+## Syntax
+
+| Form                    | Behavior when the variable is set | Behavior when the variable is unset or empty |
+|-------------------------|-----------------------------------|----------------------------------------------|
+| `${VAR_NAME}`           | Replaced by the variable's value. | Tooling SHOULD surface an error; it MUST NOT silently substitute an empty string. |
+| `${VAR_NAME:-default}`  | Replaced by the variable's value. | Replaced by `default`, verbatim.             |
+
+## Tooling behavior
+
+* Tools MUST resolve `${VAR_NAME}` references before using the value for any purpose.
+* If a referenced variable cannot be resolved (and no default is supplied), tools SHOULD surface an error and MUST NOT silently substitute an empty string.
+* Tools MUST preserve unresolved `${VAR_NAME}` and `${VAR_NAME:-default}` tokens verbatim when serializing a contract back to YAML (round-trip safety).
+* Tools MAY define their own resolution order across sources (for example, OS environment variable before `.env` file).
+
+## Notes
+
+* Interpolation applies to **string** values only. A field typed as an integer or boolean in the JSON schema (such as a server `port`) cannot hold a variable reference: the unresolved token is a string and the schema rejects it.
+* No new section or field is added to the standard: a contract using variables validates against the standard JSON schema as-is.
+
+[Back to TOC](README.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,7 @@ nav:
       - Custom: 'custom-other-properties.md'
       - Authoritative Definitions: 'authoritative-definitions.md'
       - Tags: 'tags.md'
+      - Variables: 'variables.md'
   - Examples:
       - 'examples/README.md'
       - '...'

--- a/src/script/negative-tests/variables-in-integer-field.odcs.yaml
+++ b/src/script/negative-tests/variables-in-integer-field.odcs.yaml
@@ -1,0 +1,23 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# RFC-0050 negative test: variable interpolation applies to STRING values only.
+# A `postgresql` server `port` is typed as an integer, so the unresolved
+# ${DB_PORT} token (a string) MUST be rejected by the schema.
+
+version: 1.0.0
+apiVersion: v3.2.0
+kind: DataContract
+id: 9d8f1c3a-5b2e-4f7d-a6c4-0e1b2d3c4f5a
+status: active
+servers:
+  - server: prod_db
+    environment: prod
+    type: postgresql
+    host: ${DB_HOST}
+    port: ${DB_PORT}
+    database: orders
+    schema: public
+schema:
+  - name: orders
+    physicalType: table


### PR DESCRIPTION
Applies **[RFC-0050: Variables](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0050-variables.md)** (approved by the TSC on 2026-07-13, Option B) to ODCS v3.2.0.

- **CHANGELOG.md** — v3.2.0 entry.
- **docs/variables.md** — new page (nav + TOC updated): `${VAR_NAME}` / `${VAR_NAME:-default}` syntax, tooling behavior (resolve-before-use, no silent empty string, round-trip safety), string-values-only note.
- **docs/examples/fundamentals/variables.odcs.yaml** — positive example (validates against the v3.2.0 schema).
- **src/script/negative-tests/variables-in-integer-field.odcs.yaml** — an unresolved `${DB_PORT}` token in the integer-typed `port` field is rejected.
- **No JSON-schema change** — RFC-0050 deliberately adds no section or field to the standard.

Validation: `validate-examples.sh` Total failed=0; `validate-negative.sh` Total failed=0 (new fixture PASSED/rejected).

Shared RFC: also lands in ODPS v1.1.0 and OORS v1.0.0 via separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)