### PR TITLE
feat(rfc-0047): add optional `id` to relationship objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,10 @@ RFCs targeting v3.2.0 are tracked under [`tsc/rfcs/`](https://github.com/bitol-i
   * The POSIX `${VAR_NAME:-default}` form supplies an inline default, used when the variable is unset or empty.
   * Tools MUST resolve references before using a value, SHOULD error on unresolvable references (never silently substitute an empty string), and MUST preserve unresolved tokens verbatim when serializing back to YAML.
   * Non-breaking: no new section or field is added to the standard; interpolation applies to string values only.
+* **Adds** `id` to relationship objects ([RFC 0047](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0047-relationship-id.md)):
+  * New optional `id` string on `RelationshipBase` (surfaced on both schema-level and property-level relationships), completing the stable-identifier work of RFC-0026a for the last referenceable array-item object that lacked one.
+  * MUST be unique within its containing `relationships` array; SHOULD be stable across contract versions; cannot contain `.` `#` `/` `\` `@` `!` `%` `&` `^`.
+  * Non-breaking, as `id` is optional.
 * **Changes** to Servers:
   * Add optional Athena Server `workgroup` field and fix `stagingDir` to be optional in schema.
 

--- a/docs/examples/references/relationships.odcs.yaml
+++ b/docs/examples/references/relationships.odcs.yaml
@@ -8,7 +8,7 @@ apiVersion: v3.2.0
 status: active
 name: orders_with_relationships
 description:
-  purpose: Demonstrate property-level, schema-level, composite, and shorthand foreign-key relationships (RFC 0026).
+  purpose: Demonstrate property-level, schema-level, composite, and shorthand foreign-key relationships (RFC 0026), each carrying a stable relationship id (RFC 0047).
 
 schema:
   - id: customers_obj
@@ -62,7 +62,8 @@ schema:
         logicalType: string
         physicalType: VARCHAR(36)
         relationships:
-          - to: customers.id
+          - id: fk_order_customer
+            to: customers.id
             type: foreignKey
             customProperties:
               - property: cardinality
@@ -73,14 +74,16 @@ schema:
         name: shipping_address_street
         logicalType: string
         relationships:
-          - to: addresses.address_street
+          - id: fk_order_shipping_address
+            to: addresses.address_street
             type: foreignKey
 
     # Schema-level relationships: explicit `from` and `to`,
     # including a composite (multi-column) foreign key.
     # Both sides use the shorthand `schema.property` notation.
     relationships:
-      - type: foreignKey
+      - id: fk_orders_address_composite
+        type: foreignKey
         from: ['orders.customer_id', 'orders.shipping_address_street']
         to:   ['addresses.customer_id', 'addresses.address_street']
         customProperties:

--- a/docs/references.md
+++ b/docs/references.md
@@ -121,6 +121,7 @@ Relationships can be defined in two ways:
 | -------------------------------- | ------ | ----------------- | ----------------- | --------------------------------------------------------------------------------- |
 | relationships                    | array  | Relationships     | No                | Array of relationship definitions                                                 |
 | relationships[].from             | string | From              | Context-dependent | Source property reference - Required at schema level, forbidden at property level |
+| relationships[].id               | string | ID                | No                | Optional stable identifier for the relationship, unique within its containing `relationships` array. Recommended for elements that will be referenced. Cannot contain: `.` `#` `/` `\` `@` `!` `%` `&` `^` (RFC 0047) |
 | relationships[].to               | string | To                | Yes               | Target property reference using `schema.property` notation                        |
 | relationships[].type             | string | Type              | No                | Type of relationship (defaults to `foreignKey`)                                   |
 | relationships[].customProperties | array  | Custom Properties | No                | Additional metadata about the relationship                                        |

--- a/schema/odcs-json-schema-latest.json
+++ b/schema/odcs-json-schema-latest.json
@@ -3146,6 +3146,10 @@
       "type": "object",
       "description": "Base definition for relationships between properties, typically for foreign key constraints.",
       "properties": {
+        "id": {
+          "type": "string",
+          "description": "Optional stable identifier for this relationship, unique within its containing relationships array. SHOULD remain stable across contract versions. Cannot contain: . # / \\ @ ! % & ^"
+        },
         "type": {
           "type": "string",
           "description": "The type of relationship. Defaults to 'foreignKey'.",

--- a/schema/odcs-json-schema-v3.2.0.json
+++ b/schema/odcs-json-schema-v3.2.0.json
@@ -3145,6 +3145,10 @@
       "type": "object",
       "description": "Base definition for relationships between properties, typically for foreign key constraints.",
       "properties": {
+        "id": {
+          "type": "string",
+          "description": "Optional stable identifier for this relationship, unique within its containing relationships array. SHOULD remain stable across contract versions. Cannot contain: . # / \\ @ ! % & ^"
+        },
         "type": {
           "type": "string",
           "description": "The type of relationship. Defaults to 'foreignKey'.",


### PR DESCRIPTION
Applies **[RFC-0047: Adding `id` to Relationship Objects](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0047-relationship-id.md)** (approved by the TSC on 2026-07-14) to ODCS v3.2.0.

- **CHANGELOG.md** — v3.2.0 entry.
- **Both JSON schemas** (`latest` + `v3.2.0`, in lockstep) — add optional `id` string as the first property of `RelationshipBase`, inherited by `RelationshipSchemaLevel` and `RelationshipPropertyLevel`. Exact shape from the RFC (type string, description with the char restriction); no `pattern`, matching the RFC.
- **docs/references.md** — new `relationships[].id` row in the Field Definitions table (placed alphabetically per the ODxS table-sort rule).
- **docs/examples/references/relationships.odcs.yaml** — every relationship now carries a stable `id` (positive sample).

**No negative-test fixture.** RFC-0047 adds only an optional string with no schema-enforced `pattern` or uniqueness (the id-format rules are textual SHOULD/MUST, like every other ODCS `id`), so there is no schema-level violation to assert — consistent with how RFC-0026a ids were handled.

Validation: `validate-examples.sh` Total failed=0; `validate-negative.sh` Total failed=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)