### PR TITLE
feat(rfc-0049): add `iceberg` server type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,9 @@ RFCs targeting v3.2.0 are tracked under [`tsc/rfcs/`](https://github.com/bitol-i
   * New optional `id` string on `RelationshipBase` (surfaced on both schema-level and property-level relationships), completing the stable-identifier work of RFC-0026a for the last referenceable array-item object that lacked one.
   * MUST be unique within its containing `relationships` array; SHOULD be stable across contract versions; cannot contain `.` `#` `/` `\` `@` `!` `%` `&` `^`.
   * Non-breaking, as `id` is optional.
+* **Adds** Apache Iceberg server type ([RFC 0049](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0049-iceberg-server-type.md)):
+  * New `iceberg` server `type` describing access to Apache Iceberg catalogs through the standardized Iceberg REST API, with required `catalog` and `catalogUrl` plus optional `namespace` and `warehouse`.
+  * Non-breaking: adds a new optional server type.
 * **Changes** to Servers:
   * Add optional Athena Server `workgroup` field and fix `stagingDir` to be optional in schema.
 

--- a/docs/examples/server/iceberg-server.odcs.yaml
+++ b/docs/examples/server/iceberg-server.odcs.yaml
@@ -1,0 +1,25 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Demonstrates RFC-0049: the `iceberg` server type for Apache Iceberg catalogs
+# accessed through the standardized Iceberg REST API.
+
+version: 1.0.0
+apiVersion: v3.2.0
+kind: DataContract
+id: 7f2e4c91-3a6d-4b8e-9c0f-1d2e3f4a5b6c
+status: active
+servers:
+  - server: prod
+    type: iceberg
+    catalog: prod_catalog
+    catalogUrl: https://catalog.acme.com
+    namespace: acme_db.sales
+    warehouse: s3://acme-warehouse/sales/
+schema:
+  - name: sales
+    physicalType: table
+    properties:
+      - name: sale_id
+        logicalType: string
+        required: true

--- a/docs/infrastructure-servers.md
+++ b/docs/infrastructure-servers.md
@@ -180,6 +180,17 @@ If your server is not in the list, please use [custom](#custom-server) and sugge
 | host     | string  | Host     | Yes      | The host to the Hive server.                    |
 | port     | integer | Port     | No       | The port to the Hive server. Defaults to 10000. |
 
+### Apache Iceberg
+
+[Apache Iceberg](https://iceberg.apache.org/) is an open table format for large analytic datasets, accessed through the standardized Iceberg REST catalog API (Polaris, S3 Tables, Nessie, Unity Catalog, Glue, etc.). Added in ODCS v3.2.0 ([RFC 0049](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0049-iceberg-server-type.md)).
+
+| Key        | Type   | UX Label    | Required | Description                                                                                                 |
+| ---------- | ------ | ----------- | -------- | ----------------------------------------------------------------------------------------------------------- |
+| catalog    | string | Catalog     | Yes      | Catalog name as registered in the query engine or catalog service (e.g. `my_catalog`).                      |
+| catalogUrl | string | Catalog URL | Yes      | URL of the Iceberg compatible REST catalog service (Polaris, S3 Tables, Nessie, Unity Catalog, Glue, etc.). |
+| namespace  | string | Namespace   | No       | Dot-separated namespace path within the catalog (e.g. `db.schema` or just `db`).                            |
+| warehouse  | string | Warehouse   | No       | Base storage location of the warehouse (e.g. `s3://my-bucket/warehouse/`).                                  |
+
 ### Apache Impala
 
 [Apache Impala](https://impala.apache.org/) is a massively parallel processing (MPP) SQL query engine for data stored in Apache Hadoop clusters. Impala provides high-performance, low-latency SQL queries on data stored in HDFS and Apache HBase, enabling interactive exploration and analytics without data movement or transformation.

--- a/schema/odcs-json-schema-latest.json
+++ b/schema/odcs-json-schema-latest.json
@@ -233,7 +233,7 @@
           "description": "Type of the server.",
           "enum": [
             "api", "athena", "azure", "bigquery", "clickhouse", "databricks", "denodo", "dremio",
-            "duckdb", "glue", "hana", "cloudsql", "db2", "hive", "impala", "informix", "kafka", "kinesis", "local",
+            "duckdb", "glue", "hana", "cloudsql", "db2", "hive", "iceberg", "impala", "informix", "kafka", "kinesis", "local",
             "mysql", "oracle", "postgresql", "postgres", "presto", "pubsub",
             "redshift", "s3", "sftp", "snowflake", "sqlserver", "synapse", "trino", "vertica", "zen", "custom"
           ]
@@ -556,6 +556,19 @@
           },
           "then": {
             "$ref": "#/$defs/ServerSource/HanaServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "iceberg"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/IcebergServer"
           }
         },
         {
@@ -1439,6 +1452,36 @@
         },
         "required": [
           "host"
+        ]
+      },
+      "IcebergServer": {
+        "type": "object",
+        "title": "IcebergServer",
+        "properties": {
+          "catalog": {
+            "type": "string",
+            "description": "Catalog name as registered in the query engine or catalog service.",
+            "examples": ["my_catalog"]
+          },
+          "catalogUrl": {
+            "type": "string",
+            "format": "uri",
+            "description": "URL of the Iceberg compatible REST catalog service (Polaris, S3 Tables, Nessie, Unity Catalog, Glue, etc.)",
+            "examples": ["https://my-catalog-service.com"]
+          },
+          "namespace": {
+            "type": "string",
+            "description": "Dot-separated namespace/schema path within the catalog (e.g. db.schema or just db)."
+          },
+          "warehouse": {
+            "type": "string",
+            "description": "Logical catalog or base location for the catalog to use.",
+            "examples": ["s3://my-bucket/warehouse/sales/", "production", "development"]
+          }
+        },
+        "required": [
+          "catalog",
+          "catalogUrl"
         ]
       },
       "PrestoServer": {

--- a/schema/odcs-json-schema-v3.2.0.json
+++ b/schema/odcs-json-schema-v3.2.0.json
@@ -232,7 +232,7 @@
           "description": "Type of the server.",
           "enum": [
             "api", "athena", "azure", "bigquery", "clickhouse", "databricks", "denodo", "dremio",
-            "duckdb", "glue", "hana", "cloudsql", "db2", "hive", "impala", "informix", "kafka", "kinesis", "local",
+            "duckdb", "glue", "hana", "cloudsql", "db2", "hive", "iceberg", "impala", "informix", "kafka", "kinesis", "local",
             "mysql", "oracle", "postgresql", "postgres", "presto", "pubsub",
             "redshift", "s3", "sftp", "snowflake", "sqlserver", "synapse", "trino", "vertica", "zen", "custom"
           ]
@@ -555,6 +555,19 @@
           },
           "then": {
             "$ref": "#/$defs/ServerSource/HanaServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "iceberg"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/IcebergServer"
           }
         },
         {
@@ -1438,6 +1451,36 @@
         },
         "required": [
           "host"
+        ]
+      },
+      "IcebergServer": {
+        "type": "object",
+        "title": "IcebergServer",
+        "properties": {
+          "catalog": {
+            "type": "string",
+            "description": "Catalog name as registered in the query engine or catalog service.",
+            "examples": ["my_catalog"]
+          },
+          "catalogUrl": {
+            "type": "string",
+            "format": "uri",
+            "description": "URL of the Iceberg compatible REST catalog service (Polaris, S3 Tables, Nessie, Unity Catalog, Glue, etc.)",
+            "examples": ["https://my-catalog-service.com"]
+          },
+          "namespace": {
+            "type": "string",
+            "description": "Dot-separated namespace/schema path within the catalog (e.g. db.schema or just db)."
+          },
+          "warehouse": {
+            "type": "string",
+            "description": "Logical catalog or base location for the catalog to use.",
+            "examples": ["s3://my-bucket/warehouse/sales/", "production", "development"]
+          }
+        },
+        "required": [
+          "catalog",
+          "catalogUrl"
         ]
       },
       "PrestoServer": {

--- a/src/script/negative-tests/iceberg-missing-catalogurl.odcs.yaml
+++ b/src/script/negative-tests/iceberg-missing-catalogurl.odcs.yaml
@@ -1,0 +1,20 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# RFC-0049 negative test: an `iceberg` server requires both `catalog` and
+# `catalogUrl`. Here `catalogUrl` is omitted, so the schema MUST reject this
+# contract.
+
+version: 1.0.0
+apiVersion: v3.2.0
+kind: DataContract
+id: 8a3f5d02-4b7e-4c9f-a0d1-2e3f4a5b6c7d
+status: active
+servers:
+  - server: prod
+    type: iceberg
+    catalog: prod_catalog
+    namespace: acme_db.sales
+schema:
+  - name: sales
+    physicalType: table


### PR DESCRIPTION
Applies **[RFC-0049: Apache Iceberg server type](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0049-iceberg-server-type.md)** (approved by the TSC on 2026-07-14) to ODCS v3.2.0.

- **CHANGELOG.md** — v3.2.0 entry.
- **Both JSON schemas** (`latest` + `v3.2.0`, in lockstep) — `iceberg` added to the server `type` enum; conditional dispatch to a new `IcebergServer` def with **required `catalog` + `catalogUrl`** and optional `namespace` + `warehouse`.
- **docs/infrastructure-servers.md** — new "Apache Iceberg" section with a field table.
- **docs/examples/server/iceberg-server.odcs.yaml** — positive example.
- **src/script/negative-tests/iceberg-missing-catalogurl.odcs.yaml** — omits `catalogUrl`; schema correctly rejects it.

**Note on required fields:** the RFC's field table marks `catalog` and `catalogUrl` as required, but its proposed JSON block omitted the `required` array. Per the TSC decision (and consistent with RFC-0045/HANA), both are required in the schema. This was confirmed before implementation.

Validation: `validate-examples.sh` Total failed=0; `validate-negative.sh` Total failed=0 (new fixture rejected on `IcebergServer/required`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)