### PR TITLE
docs(context): restore authoritativeDefinitions example (ontology/glossary/taxonomy)

### DIFF
--- a/docs/context.md
+++ b/docs/context.md
@@ -40,6 +40,16 @@ context:
     - id: no-individual-order-exposure
       constraint: "Do not expose individual order details; aggregate to at least country level."
       tags: ['gdpr', 'pii']
+      authoritativeDefinitions:
+        - url: https://example.com/MyGlobalAndMarvelousOntology
+          type: Ontology
+          description: Link to the ontology
+        - url: https://example.com/MySpecificAndWonderfulGlossary
+          type: Glossary
+          description: Link to the glossary
+        - url: https://example.com/OneOfManyTaxonomy
+          type: Taxonomy
+          description: Link to the taxonomy
     - constraint: "Do not join with customer PII tables without explicit data access approval."
 ```
 


### PR DESCRIPTION
The contract-level `context` example in `docs/context.md` documents `authoritativeDefinitions` (for both `constraints[]` and `verifiedStatements[]`) in the Definitions table, but the example itself no longer showed it in use. This restores the `authoritativeDefinitions` block — pointing to an Ontology, Glossary, and Taxonomy — on the `no-individual-order-exposure` constraint, matching the approved [RFC-0038](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0038-context.md) example.

Docs-only; both fenced YAML examples in the page parse cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)