### PR TITLE
feat(rfc-0050): allow string values in server port fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ RFCs targeting v3.2.0 are tracked under [`tsc/rfcs/`](https://github.com/bitol-i
   * The POSIX `${VAR_NAME:-default}` form supplies an inline default, used when the variable is unset or empty.
   * Tools MUST resolve references before using a value, SHOULD error on unresolvable references (never silently substitute an empty string), and MUST preserve unresolved tokens verbatim when serializing back to YAML.
   * Non-breaking: no new section or field is added to the standard; interpolation applies to string values only.
+  * Server `port` fields now accept a string in addition to an integer, so they can hold a variable reference such as `${DB_PORT}` or `${DB_PORT:-5432}`, which the previous integer-only type rejected.
 * **Adds** `id` to relationship objects ([RFC 0047](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0047-relationship-id.md)):
   * New optional `id` string on `RelationshipBase` (surfaced on both schema-level and property-level relationships), completing the stable-identifier work of RFC-0026a for the last referenceable array-item object that lacked one.
   * MUST be unique within its containing `relationships` array; SHOULD be stable across contract versions; cannot contain `.` `#` `/` `\` `@` `!` `%` `&` `^`.

--- a/docs/examples/fundamentals/variables.odcs.yaml
+++ b/docs/examples/fundamentals/variables.odcs.yaml
@@ -17,7 +17,7 @@ servers:
     environment: prod
     type: postgresql
     host: ${DB_HOST}
-    port: 5432
+    port: ${DB_PORT:-5432}
     database: ${DB_NAME:-orders}
     schema: ${DB_SCHEMA:-public}
 

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -24,7 +24,7 @@ servers:
     environment: prod
     type: postgresql
     host: ${DB_HOST}
-    port: 5432
+    port: ${DB_PORT:-5432}
     database: ${DB_NAME:-orders}
     schema: ${DB_SCHEMA:-public}
 ```
@@ -53,7 +53,8 @@ quality:
 
 ## Notes
 
-* Interpolation applies to **string** values only. A field typed as an integer or boolean in the JSON schema (such as a server `port`) cannot hold a variable reference: the unresolved token is a string and the schema rejects it.
+* Interpolation applies to **string** values only. A field typed as an integer or boolean in the JSON schema cannot hold a variable reference: the unresolved token is a string and the schema rejects it.
+* The server `port` is an exception: the schema accepts an integer or a string, so it can hold a variable reference such as `${DB_PORT}` or `${DB_PORT:-5432}`.
 * No new section or field is added to the standard: a contract using variables validates against the standard JSON schema as-is.
 
 [Back to TOC](README.md)

--- a/schema/odcs-json-schema-latest.json
+++ b/schema/odcs-json-schema-latest.json
@@ -217,6 +217,10 @@
       "description": "Stable technical identifier for references. Must be unique within its containing array. Cannot contain special characters ('-', '_' allowed).",
       "pattern": "^[A-Za-z0-9_-]+$"
     },
+    "Port": {
+      "type": ["integer", "string"],
+      "description": "A network port: an integer, or a string, e.g. to hold a variable reference such as ${DB_PORT} resolved at runtime (RFC 0050)."
+    },
     "Server": {
       "type": "object",
       "description": "Data source details of where data is physically stored.",
@@ -859,7 +863,7 @@
             "description": "The host of the ClickHouse server."
           },
           "port": {
-            "type": "integer",
+            "$ref": "#/$defs/Port",
             "description": "The port to the ClickHouse server."
           },
           "database": {
@@ -907,7 +911,7 @@
             "description": "The host of the Denodo server."
           },
           "port": {
-            "type": "integer",
+            "$ref": "#/$defs/Port",
             "description": "The port of the Denodo server."
           },
           "database": {
@@ -929,7 +933,7 @@
             "description": "The host of the Dremio server."
           },
           "port": {
-            "type": "integer",
+            "$ref": "#/$defs/Port",
             "description": "The port of the Dremio server."
           },
           "schema": {
@@ -1020,7 +1024,7 @@
             "description": "The host of the Google Cloud Sql server."
           },
           "port": {
-            "type": "integer",
+            "$ref": "#/$defs/Port",
             "description": "The port of the Google Cloud Sql server."
           },
           "database": {
@@ -1048,7 +1052,7 @@
             "description": "The host of the IBM DB2 server."
           },
           "port": {
-            "type": "integer",
+            "$ref": "#/$defs/Port",
             "description": "The port of the IBM DB2 server."
           },
           "database": {
@@ -1075,7 +1079,7 @@
             "description": "The host to the Hive server. "
           },
           "port": {
-            "type": "integer",
+            "$ref": "#/$defs/Port",
             "description": "The port to the Hive server. Defaults to 10000."
           },
           "database": {
@@ -1097,7 +1101,7 @@
             "description": "The host to the Impala server."
           },
           "port": {
-            "type": "integer",
+            "$ref": "#/$defs/Port",
             "description": "The port to the Impala server. Defaults to 21050."
           },
           "database": {
@@ -1119,7 +1123,7 @@
             "description": "The host to the Informix server. "
           },
           "port": {
-            "type": "integer",
+            "$ref": "#/$defs/Port",
             "description": "The port to the Informix server. Defaults to 9088."
           },
           "database": {
@@ -1141,7 +1145,7 @@
             "description": "Hostname or IP address of the Zen server."
           },
           "port": {
-            "type": "integer",
+            "$ref": "#/$defs/Port",
             "description": "Zen server SQL connections port. Defaults to 1583."
           },
           "database": {
@@ -1208,7 +1212,7 @@
             "description": "Relative or absolute path to the data file(s)."
           },
           "port": {
-            "type": "integer",
+            "$ref": "#/$defs/Port",
             "description": "Port to the server. No default value is assumed for custom servers."
           },
           "project": {
@@ -1355,7 +1359,7 @@
             "description": "The host of the MySql server."
           },
           "port": {
-            "type": "integer",
+            "$ref": "#/$defs/Port",
             "description": "The port of the MySql server."
           },
           "database": {
@@ -1381,7 +1385,7 @@
             ]
           },
           "port": {
-            "type": "integer",
+            "$ref": "#/$defs/Port",
             "description": "The port to the oracle server.",
             "examples": [
               1523
@@ -1410,7 +1414,7 @@
             "description": "The host to the Postgres server"
           },
           "port": {
-            "type": "integer",
+            "$ref": "#/$defs/Port",
             "description": "The port to the Postgres server."
           },
           "database": {
@@ -1438,7 +1442,7 @@
             "description": "Host of the HANA server."
           },
           "port": {
-            "type": "integer",
+            "$ref": "#/$defs/Port",
             "description": "Port of the HANA server."
           },
           "database": {
@@ -1664,7 +1668,7 @@
             "description": "The host to the Snowflake server"
           },
           "port": {
-            "type": "integer",
+            "$ref": "#/$defs/Port",
             "description": "The port to the Snowflake server."
           },
           "account": {
@@ -1702,7 +1706,7 @@
             ]
           },
           "port": {
-            "type": "integer",
+            "$ref": "#/$defs/Port",
             "description": "The port to the database server.",
             "default": 1433,
             "examples": [
@@ -1739,7 +1743,7 @@
             "description": "The host of the Synapse server."
           },
           "port": {
-            "type": "integer",
+            "$ref": "#/$defs/Port",
             "description": "The port of the Synapse server."
           },
           "database": {
@@ -1765,7 +1769,7 @@
             ]
           },
           "port": {
-            "type": "integer",
+            "$ref": "#/$defs/Port",
             "description": "The Trino port."
           },
           "catalog": {
@@ -1799,7 +1803,7 @@
             "description": "The host of the Vertica server."
           },
           "port": {
-            "type": "integer",
+            "$ref": "#/$defs/Port",
             "description": "The port of the Vertica server."
           },
           "database": {

--- a/schema/odcs-json-schema-v3.2.0.json
+++ b/schema/odcs-json-schema-v3.2.0.json
@@ -216,6 +216,10 @@
       "description": "Stable technical identifier for references. Must be unique within its containing array. Cannot contain special characters ('-', '_' allowed).",
       "pattern": "^[A-Za-z0-9_-]+$"
     },
+    "Port": {
+      "type": ["integer", "string"],
+      "description": "A network port: an integer, or a string, e.g. to hold a variable reference such as ${DB_PORT} resolved at runtime (RFC 0050)."
+    },
     "Server": {
       "type": "object",
       "description": "Data source details of where data is physically stored.",
@@ -858,7 +862,7 @@
             "description": "The host of the ClickHouse server."
           },
           "port": {
-            "type": "integer",
+            "$ref": "#/$defs/Port",
             "description": "The port to the ClickHouse server."
           },
           "database": {
@@ -906,7 +910,7 @@
             "description": "The host of the Denodo server."
           },
           "port": {
-            "type": "integer",
+            "$ref": "#/$defs/Port",
             "description": "The port of the Denodo server."
           },
           "database": {
@@ -928,7 +932,7 @@
             "description": "The host of the Dremio server."
           },
           "port": {
-            "type": "integer",
+            "$ref": "#/$defs/Port",
             "description": "The port of the Dremio server."
           },
           "schema": {
@@ -1019,7 +1023,7 @@
             "description": "The host of the Google Cloud Sql server."
           },
           "port": {
-            "type": "integer",
+            "$ref": "#/$defs/Port",
             "description": "The port of the Google Cloud Sql server."
           },
           "database": {
@@ -1047,7 +1051,7 @@
             "description": "The host of the IBM DB2 server."
           },
           "port": {
-            "type": "integer",
+            "$ref": "#/$defs/Port",
             "description": "The port of the IBM DB2 server."
           },
           "database": {
@@ -1074,7 +1078,7 @@
             "description": "The host to the Hive server. "
           },
           "port": {
-            "type": "integer",
+            "$ref": "#/$defs/Port",
             "description": "The port to the Hive server. Defaults to 10000."
           },
           "database": {
@@ -1096,7 +1100,7 @@
             "description": "The host to the Impala server."
           },
           "port": {
-            "type": "integer",
+            "$ref": "#/$defs/Port",
             "description": "The port to the Impala server. Defaults to 21050."
           },
           "database": {
@@ -1118,7 +1122,7 @@
             "description": "The host to the Informix server. "
           },
           "port": {
-            "type": "integer",
+            "$ref": "#/$defs/Port",
             "description": "The port to the Informix server. Defaults to 9088."
           },
           "database": {
@@ -1140,7 +1144,7 @@
             "description": "Hostname or IP address of the Zen server."
           },
           "port": {
-            "type": "integer",
+            "$ref": "#/$defs/Port",
             "description": "Zen server SQL connections port. Defaults to 1583."
           },
           "database": {
@@ -1207,7 +1211,7 @@
             "description": "Relative or absolute path to the data file(s)."
           },
           "port": {
-            "type": "integer",
+            "$ref": "#/$defs/Port",
             "description": "Port to the server. No default value is assumed for custom servers."
           },
           "project": {
@@ -1354,7 +1358,7 @@
             "description": "The host of the MySql server."
           },
           "port": {
-            "type": "integer",
+            "$ref": "#/$defs/Port",
             "description": "The port of the MySql server."
           },
           "database": {
@@ -1380,7 +1384,7 @@
             ]
           },
           "port": {
-            "type": "integer",
+            "$ref": "#/$defs/Port",
             "description": "The port to the oracle server.",
             "examples": [
               1523
@@ -1409,7 +1413,7 @@
             "description": "The host to the Postgres server"
           },
           "port": {
-            "type": "integer",
+            "$ref": "#/$defs/Port",
             "description": "The port to the Postgres server."
           },
           "database": {
@@ -1437,7 +1441,7 @@
             "description": "Host of the HANA server."
           },
           "port": {
-            "type": "integer",
+            "$ref": "#/$defs/Port",
             "description": "Port of the HANA server."
           },
           "database": {
@@ -1663,7 +1667,7 @@
             "description": "The host to the Snowflake server"
           },
           "port": {
-            "type": "integer",
+            "$ref": "#/$defs/Port",
             "description": "The port to the Snowflake server."
           },
           "account": {
@@ -1701,7 +1705,7 @@
             ]
           },
           "port": {
-            "type": "integer",
+            "$ref": "#/$defs/Port",
             "description": "The port to the database server.",
             "default": 1433,
             "examples": [
@@ -1738,7 +1742,7 @@
             "description": "The host of the Synapse server."
           },
           "port": {
-            "type": "integer",
+            "$ref": "#/$defs/Port",
             "description": "The port of the Synapse server."
           },
           "database": {
@@ -1764,7 +1768,7 @@
             ]
           },
           "port": {
-            "type": "integer",
+            "$ref": "#/$defs/Port",
             "description": "The Trino port."
           },
           "catalog": {
@@ -1798,7 +1802,7 @@
             "description": "The host of the Vertica server."
           },
           "port": {
-            "type": "integer",
+            "$ref": "#/$defs/Port",
             "description": "The port of the Vertica server."
           },
           "database": {

--- a/src/script/negative-tests/variables-in-integer-field.odcs.yaml
+++ b/src/script/negative-tests/variables-in-integer-field.odcs.yaml
@@ -2,8 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # RFC-0050 negative test: variable interpolation applies to STRING values only.
-# A `postgresql` server `port` is typed as an integer, so the unresolved
-# ${DB_PORT} token (a string) MUST be rejected by the schema.
+# `primaryKeyPosition` is typed as an integer, so the unresolved ${KEY_POS}
+# token (a string) MUST be rejected by the schema. (The server `port` is an
+# explicit exception: it accepts integer or string, so it can hold a
+# variable reference.)
 
 version: 1.0.0
 apiVersion: v3.2.0
@@ -21,3 +23,9 @@ servers:
 schema:
   - name: orders
     physicalType: table
+    properties:
+      - name: order_id
+        logicalType: string
+        physicalType: varchar(36)
+        primaryKey: true
+        primaryKeyPosition: ${KEY_POS}


### PR DESCRIPTION
## Summary

[RFC 0050](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0050-variables.md) allows `${VAR_NAME}` references in string values only. Server `port` fields are typed as integers, so a contract using `port: ${DB_PORT}` failed schema validation. As discussed in the working group Slack, this relaxes `port` to accept a string as well.

## Changes

- All 19 server `port` definitions in `odcs-json-schema-v3.2.0.json` and `odcs-json-schema-latest.json` now reference a shared `$defs/Port` typed as `integer` or `string`, so a port can hold a variable reference such as `${DB_PORT}` or `${DB_PORT:-5432}`. Per-server descriptions and the SQL Server default are unchanged.
- `docs/variables.md`: the note forbidding variables in `port` is replaced by the new exception; the example now uses `port: ${DB_PORT:-5432}`.
- `docs/examples/fundamentals/variables.odcs.yaml`: example uses `port: ${DB_PORT:-5432}`.
- `CHANGELOG.md`: sub-bullet on the RFC 0050 entry.
- The `variables-in-integer-field` negative test asserted the old behavior; it now uses `primaryKeyPosition` to keep verifying that other integer fields remain integer-only.

## Testing

- `src/script/validate-examples.sh`: all examples pass.
- `src/script/validate-negative.sh`: all 22 negative tests correctly rejected.