### PR TITLE
docs: add Enkinex ODCS library and tutorial

### DIFF
--- a/resources.md
+++ b/resources.md
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 # Articles & Other Resources
 
 ## Articles
-
+* 2026-08-07 - [Enkinex ODCS Tutorial: Data Contract as Code](https://enkinex.org/docs/governance/odcs/tutorial/)
 * 2025-12-07 - [Bitol Announces ODCS v3.1.0: Stronger, Smarter, and Stricter](https://bitol.io/bitol-announces-odcs-v3-1-0-stronger-smarter-and-stricter/)
 * 2025-12-07 - [ODCS v3.1.0 is Here: Relationships, Richer Metadata, and Stricter Validation](https://dataintelligenceplatform.substack.com/p/odcs-v310-is-here-relationships-richer)
 * 2026-02-24 - [Five Levels Between Chaos and (Almost) AI-Ready Data](https://dataintelligenceplatform.substack.com/p/five-levels-between-chaos-and-almost)

--- a/vendors.md
+++ b/vendors.md
@@ -17,6 +17,8 @@ A non-exhaustive, alphabetical list of organizations offering solutions natively
 * [Data Contract Playground](https://data-catering.github.io/data-contract-playground/) - Playground site for creating, exporting, and validating data contracts.
 * [DataVow](https://github.com/ludovicschmetz-stack/datavow) - Open-source CLI for ODCS v3.1 data contract enforcement with DuckDB validation, dbt test sync, GitHub Action, and Vow Score reporting
 * [DQC.ai | DQ PLATFORM](https://www.dqc.ai/dqc-platform) - [Enhancing Data Quality with ODCS: A Standard Ensured by the DQ Platform](https://www.dqc.ai/post/enhancing-data-quality-with-odcs-a-standard-ensured-by-the-dq-platform).
+* [Enkinex ODCS](https://odcs.enkinex.org) - Open-source KCL library for writing data governance as code. Provides modular, typed ODCS schemas (common, catalog, contract, iam, quality, server) with constraints, two-way
+  validation, and YAML export.
 * [Entropy Data](https://www.entropy-data.com) - Data Product Marketplace built on Data Contracts. Allows contract-first development of data products.
 * [FLUID Forge](https://github.com/Agenticstiger/forge-cli) - Open-source Python CLI for authoring, planning, and applying data contracts. Bidirectional ODCS v3.1.0 import/export with lossless round-trip, Bitol ODPS v1.0.0 product wrapper with per-port contractId linking, native cloud apply (AWS Glue, BigQuery, Snowflake), and Data Mesh Manager publish.
 * [IBM](https://www.ibm.com/) - Supports [data contracts](https://www.ibm.com/docs/en/announcements/watsonxdata-intelligence-v23-introduces-support-openlineage-natural-language-sql-functionality-open-data-contracts), aligned with the Open Data Contract Standard, via its data & AI platform, watsonx 


### PR DESCRIPTION
Adds the Enkinex ODCS library to `vendors.md` and the Enkinex ODCS Tutorial to `resources.md`.

  - **vendors.md** — open-source KCL library implementing ODCS as modular typed schemas: https://odcs.enkinex.org
  - **resources.md** — The walkthrough for authoring ODCS contracts as KCL code: https://enkinex.org/docs/governance/odcs/tutorial/

  Targeting `dev` per maintainer guidance; docs-only, no schema or example changes.