### PR TITLE
feat(rfc-0058): add `exasol` server type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,10 @@ RFCs targeting v3.2.0 are tracked under [`tsc/rfcs/`](https://github.com/bitol-i
 * **Adds** Apache Iceberg server type ([RFC 0049](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0049-iceberg-server-type.md)):
   * New `iceberg` server `type` describing access to Apache Iceberg catalogs through the standardized Iceberg REST API, with required `catalog` and `catalogUrl` plus optional `namespace` and `warehouse`.
   * Non-breaking: adds a new optional server type.
+* **Adds** Exasol server type ([RFC 0058](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0058-exasol-server-type.md)):
+  * New `exasol` server `type` describing data served from Exasol, an in-memory MPP analytics database, with required `host` plus optional `port` (defaults to `8563`) and `schema`.
+  * No `database` field: an Exasol cluster runs a single database and the schema is the namespace. `host` may be a cluster connection range, e.g. `n11..14.acme.com`.
+  * Non-breaking: adds a new optional server type.
 * **Changes** to Servers:
   * Add optional Athena Server `workgroup` field and fix `stagingDir` to be optional in schema.
 

--- a/docs/examples/server/exasol-server.odcs.yaml
+++ b/docs/examples/server/exasol-server.odcs.yaml
@@ -1,0 +1,25 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Demonstrates RFC-0058: the `exasol` server type for Exasol, an in-memory MPP
+# analytics database. An Exasol cluster runs a single database, so the schema is
+# the namespace and there is no `database` field.
+
+version: 1.0.0
+apiVersion: v3.2.0
+kind: DataContract
+id: 5c9a1e73-8d24-4f60-b1a7-6e0c3b5d9f42
+status: active
+servers:
+  - server: prod
+    type: exasol
+    host: exasol.acme.com
+    port: 8563
+    schema: SALES
+schema:
+  - name: sales
+    physicalType: table
+    properties:
+      - name: sale_id
+        logicalType: string
+        required: true

--- a/docs/infrastructure-servers.md
+++ b/docs/infrastructure-servers.md
@@ -50,7 +50,7 @@ servers:
 | id               | string | ID                | No       | A unique identifier used to reduce the risk of collisions, such as a UUID.                                                                                                                                                                                                                                                |
 | roles            | array  | Roles             | No       | List of roles that have access to the server. Check [roles](./roles.md) section for more details.                                                                                                                                                                                                                         |
 | server           | string | Server            | Yes      | Identifier of the server.                                                                                                                                                                                                                                                                                                 |
-| type             | string | Type              | Yes      | Type of the server. Can be one of: api, athena, azure, bigquery, clickhouse, cloudsql, custom, databricks, db2, denodo, dremio, duckdb, glue, hive, impala, informix, kafka, kinesis, local, mysql, oracle, postgres, postgresql, presto, pubsub, redshift, s3, sftp, snowflake, sqlserver, synapse, trino, vertica, zen. |
+| type             | string | Type              | Yes      | Type of the server. Can be one of: api, athena, azure, bigquery, clickhouse, cloudsql, custom, databricks, db2, denodo, dremio, duckdb, exasol, glue, hive, impala, informix, kafka, kinesis, local, mysql, oracle, postgres, postgresql, presto, pubsub, redshift, s3, sftp, snowflake, sqlserver, synapse, trino, vertica, zen. |
 | customProperties | array  | Custom Properties | No       | Custom properties that are not part of the standard.                                                                                                                                                                                                                                                                      |
 
 ## Specific Server Properties
@@ -159,6 +159,18 @@ If your server is not in the list, please use [custom](#custom-server) and sugge
 | -------- | ------ | -------- | -------- | ----------------------------- |
 | database | string | Database | Yes      | Path to duckdb database file. |
 | schema   | string | Schema   | No       | The name of the schema.       |
+
+### Exasol
+
+[Exasol](https://www.exasol.com/) is an in-memory, massively parallel processing (MPP) analytics database used as an enterprise data warehouse. Added in ODCS v3.2.0 ([RFC 0058](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0058-exasol-server-type.md)).
+
+An Exasol cluster runs a single database and the schema is the namespace, so there is no `database` field.
+
+| Key    | Type    | UX Label | Required | Description                                                                          |
+| ------ | ------- | -------- | -------- | -------------------------------------------------------------------------------------- |
+| host   | string  | Host     | Yes      | Host of the Exasol server. May be a cluster connection range, e.g. `n11..14.acme.com`. |
+| port   | integer | Port     | No       | Port of the Exasol server. Defaults to 8563.                                         |
+| schema | string  | Schema   | No       | Name of the schema.                                                                  |
 
 ### Amazon Glue
 

--- a/schema/odcs-json-schema-latest.json
+++ b/schema/odcs-json-schema-latest.json
@@ -237,7 +237,7 @@
           "description": "Type of the server.",
           "enum": [
             "api", "athena", "azure", "bigquery", "clickhouse", "databricks", "denodo", "dremio",
-            "duckdb", "glue", "hana", "cloudsql", "db2", "hive", "iceberg", "impala", "informix", "kafka", "kinesis", "local",
+            "duckdb", "exasol", "glue", "hana", "cloudsql", "db2", "hive", "iceberg", "impala", "informix", "kafka", "kinesis", "local",
             "mysql", "oracle", "postgresql", "postgres", "presto", "pubsub",
             "redshift", "s3", "sftp", "snowflake", "sqlserver", "synapse", "trino", "vertica", "zen", "custom"
           ]
@@ -378,6 +378,19 @@
           },
           "then": {
             "$ref": "#/$defs/ServerSource/DuckdbServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "exasol"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/ExasolServer"
           }
         },
         {
@@ -961,6 +974,35 @@
         },
         "required": [
           "database"
+        ]
+      },
+      "ExasolServer": {
+        "type": "object",
+        "title": "ExasolServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "Host of the Exasol server. May be a cluster connection range.",
+            "examples": [
+              "exasol.acme.com",
+              "n11..14.acme.com"
+            ]
+          },
+          "port": {
+            "$ref": "#/$defs/Port",
+            "description": "Port of the Exasol server.",
+            "default": 8563,
+            "examples": [
+              8563
+            ]
+          },
+          "schema": {
+            "type": "string",
+            "description": "Name of the schema."
+          }
+        },
+        "required": [
+          "host"
         ]
       },
       "GlueServer": {

--- a/schema/odcs-json-schema-v3.2.0.json
+++ b/schema/odcs-json-schema-v3.2.0.json
@@ -236,7 +236,7 @@
           "description": "Type of the server.",
           "enum": [
             "api", "athena", "azure", "bigquery", "clickhouse", "databricks", "denodo", "dremio",
-            "duckdb", "glue", "hana", "cloudsql", "db2", "hive", "iceberg", "impala", "informix", "kafka", "kinesis", "local",
+            "duckdb", "exasol", "glue", "hana", "cloudsql", "db2", "hive", "iceberg", "impala", "informix", "kafka", "kinesis", "local",
             "mysql", "oracle", "postgresql", "postgres", "presto", "pubsub",
             "redshift", "s3", "sftp", "snowflake", "sqlserver", "synapse", "trino", "vertica", "zen", "custom"
           ]
@@ -377,6 +377,19 @@
           },
           "then": {
             "$ref": "#/$defs/ServerSource/DuckdbServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "exasol"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/ExasolServer"
           }
         },
         {
@@ -960,6 +973,35 @@
         },
         "required": [
           "database"
+        ]
+      },
+      "ExasolServer": {
+        "type": "object",
+        "title": "ExasolServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "Host of the Exasol server. May be a cluster connection range.",
+            "examples": [
+              "exasol.acme.com",
+              "n11..14.acme.com"
+            ]
+          },
+          "port": {
+            "$ref": "#/$defs/Port",
+            "description": "Port of the Exasol server.",
+            "default": 8563,
+            "examples": [
+              8563
+            ]
+          },
+          "schema": {
+            "type": "string",
+            "description": "Name of the schema."
+          }
+        },
+        "required": [
+          "host"
         ]
       },
       "GlueServer": {

--- a/src/script/negative-tests/exasol-missing-host.odcs.yaml
+++ b/src/script/negative-tests/exasol-missing-host.odcs.yaml
@@ -1,0 +1,19 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# RFC-0058 negative test: an `exasol` server requires `host`. Here `host` is
+# omitted, so the schema MUST reject this contract.
+
+version: 1.0.0
+apiVersion: v3.2.0
+kind: DataContract
+id: 6d0b2f84-9e35-4a71-c2b8-7f1d4c6e0a53
+status: active
+servers:
+  - server: prod
+    type: exasol
+    port: 8563
+    schema: SALES
+schema:
+  - name: sales
+    physicalType: table


### PR DESCRIPTION
Applies **[RFC-0058 — Exasol server type](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0058-exasol-server-type.md)** (champion: Jochen Christ, approved by the TSC 2026-08-05) to ODCS v3.2.0.

Exasol is an in-memory MPP analytics database used as an enterprise data warehouse. Until now users had to fall back on `custom`, losing structured, validatable connection metadata.

## Field shape (per the RFC field table)

| Field | Type | Required | Notes |
| --- | --- | --- | --- |
| `type` | string | Yes | `exasol` |
| `host` | string | Yes | May be a cluster connection range, e.g. `n11..14.acme.com` |
| `port` | integer/string | No | Defaults to `8563` |
| `schema` | string | No | Name of the schema |

No `database` field — an Exasol cluster runs a single database and the schema is the namespace.

## Changes

- `CHANGELOG.md` — entry under v3.2.0 (IN PROGRESS), linking the approved RFC
- `schema/odcs-json-schema-latest.json` **and** `schema/odcs-json-schema-v3.2.0.json` — updated in lockstep: `exasol` enum value, `if/then` dispatch, and the `ExasolServer` def (`required: [host]`, `port` via `$defs/Port` so RFC-0050 variable references keep working)
- `docs/infrastructure-servers.md` — new **Exasol** section + `exasol` added to the `type` value list
- `docs/examples/server/exasol-server.odcs.yaml` — positive example
- `src/script/negative-tests/exasol-missing-host.odcs.yaml` — negative test: `host` omitted

## Validation

- `src/script/validate-examples.sh` → exit 0, `Total failed=0`; the new example validates
- `src/script/validate-negative.sh` → exit 0, `Total failed=0`; the new fixture is rejected with `must have required property 'host'`

Non-breaking: adds a new optional server type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)