### PR TITLE
docs(servers): add a definition to every server type, spell out HCL/IBM Informix

### DIFF
--- a/docs/infrastructure-servers.md
+++ b/docs/infrastructure-servers.md
@@ -43,15 +43,15 @@ servers:
 
 ### Common Server Properties
 
-| Key              | Type   | UX label          | Required | Description                                                                                                                                                                                                                                                                                                               |
-| ---------------- | ------ | ----------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| description      | string | Description       | No       | Description of the server.                                                                                                                                                                                                                                                                                                |
-| environment      | string | Environment       | No       | Environment of the server. Examples includes: prod, preprod, dev, uat.                                                                                                                                                                                                                                                    |
-| id               | string | ID                | No       | A unique identifier used to reduce the risk of collisions, such as a UUID.                                                                                                                                                                                                                                                |
-| roles            | array  | Roles             | No       | List of roles that have access to the server. Check [roles](./roles.md) section for more details.                                                                                                                                                                                                                         |
-| server           | string | Server            | Yes      | Identifier of the server.                                                                                                                                                                                                                                                                                                 |
+| Key              | Type   | UX label          | Required | Description                                                                                                                                                                                                                                                                                                                       |
+| ---------------- | ------ | ----------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| description      | string | Description       | No       | Description of the server.                                                                                                                                                                                                                                                                                                        |
+| environment      | string | Environment       | No       | Environment of the server. Examples includes: prod, preprod, dev, uat.                                                                                                                                                                                                                                                            |
+| id               | string | ID                | No       | A unique identifier used to reduce the risk of collisions, such as a UUID.                                                                                                                                                                                                                                                        |
+| roles            | array  | Roles             | No       | List of roles that have access to the server. Check [roles](./roles.md) section for more details.                                                                                                                                                                                                                                 |
+| server           | string | Server            | Yes      | Identifier of the server.                                                                                                                                                                                                                                                                                                         |
 | type             | string | Type              | Yes      | Type of the server. Can be one of: api, athena, azure, bigquery, clickhouse, cloudsql, custom, databricks, db2, denodo, dremio, duckdb, exasol, glue, hive, impala, informix, kafka, kinesis, local, mysql, oracle, postgres, postgresql, presto, pubsub, redshift, s3, sftp, snowflake, sqlserver, synapse, trino, vertica, zen. |
-| customProperties | array  | Custom Properties | No       | Custom properties that are not part of the standard.                                                                                                                                                                                                                                                                      |
+| customProperties | array  | Custom Properties | No       | Custom properties that are not part of the standard.                                                                                                                                                                                                                                                                              |
 
 ## Specific Server Properties
 
@@ -62,6 +62,8 @@ Each server type can be customized with different properties such as `host`, `po
 If your server is not in the list, please use [custom](#custom-server) and suggest it as an improvement. Possible values for `type` are:
 
 ### API Server
+
+An API server describes data that is exposed through a network API rather than served from a database or file storage. The endpoint a consumer calls is identified by its URL.
 
 | Key          | Type   | UX Label | Required | Description    |
 | ------------ | ------ | -------- | -------- | -------------- |
@@ -80,6 +82,8 @@ If your server is not in the list, please use [custom](#custom-server) and sugge
 | workgroup  | string | Workgroup         | No       | The Athena workgroup to use. Workgroups can enforce query result location and other client-side settings via the 'Override client-side settings' option.         |
 
 ### Azure Server
+
+[Azure Blob Storage](https://azure.microsoft.com/en-us/products/storage/blobs) and [Azure Data Lake Storage (ADLS)](https://azure.microsoft.com/en-us/products/storage/data-lake-storage) are the Microsoft Azure object storage services for unstructured data and large-scale analytics workloads.
 
 | Key       | Type   | UX Label  | Required | Description                                                                                           |
 | --------- | ------ | --------- | -------- | ----------------------------------------------------------------------------------------------------- |
@@ -120,6 +124,8 @@ If your server is not in the list, please use [custom](#custom-server) and sugge
 
 ### Databricks Server
 
+[Databricks](https://www.databricks.com/) is a cloud-based data platform, built on Apache Spark, that unifies data warehousing and data lakes under the lakehouse architecture.
+
 | Key     | Type   | UX Label | Required | Description                           |
 | ------- | ------ | -------- | -------- | ------------------------------------- |
 | catalog | string | Catalog  | Yes      | The name of the Hive or Unity catalog |
@@ -127,6 +133,8 @@ If your server is not in the list, please use [custom](#custom-server) and sugge
 | schema  | string | Schema   | Yes      | The schema name in the catalog        |
 
 ### IBM Db2 Server
+
+[IBM Db2](https://www.ibm.com/products/db2) is a family of relational database management systems for transactional and analytical workloads, available both on cloud and on-premises.
 
 | Key      | Type    | UX Label | Required | Description                     |
 | -------- | ------- | -------- | -------- | ------------------------------- |
@@ -137,6 +145,8 @@ If your server is not in the list, please use [custom](#custom-server) and sugge
 
 ### Denodo Server
 
+[Denodo](https://www.denodo.com/) is a data virtualization platform that provides unified, real-time access to data spread across disparate sources, without replicating it.
+
 | Key      | Type    | UX Label | Required | Description                    |
 | -------- | ------- | -------- | -------- | ------------------------------ |
 | database | string  | Database | No       | The name of the database.      |
@@ -144,6 +154,8 @@ If your server is not in the list, please use [custom](#custom-server) and sugge
 | port     | integer | Port     | Yes      | The port of the Denodo server. |
 
 ### Dremio Server
+
+[Dremio](https://www.dremio.com/) is a lakehouse platform that runs SQL queries directly against data lake storage, built on Apache Arrow and Apache Iceberg.
 
 | Key    | Type    | UX Label | Required | Description                    |
 | ------ | ------- | -------- | -------- | ------------------------------ |
@@ -166,13 +178,15 @@ If your server is not in the list, please use [custom](#custom-server) and sugge
 
 An Exasol cluster runs a single database and the schema is the namespace, so there is no `database` field.
 
-| Key    | Type    | UX Label | Required | Description                                                                          |
+| Key    | Type    | UX Label | Required | Description                                                                            |
 | ------ | ------- | -------- | -------- | -------------------------------------------------------------------------------------- |
 | host   | string  | Host     | Yes      | Host of the Exasol server. May be a cluster connection range, e.g. `n11..14.acme.com`. |
-| port   | integer | Port     | No       | Port of the Exasol server. Defaults to 8563.                                         |
-| schema | string  | Schema   | No       | Name of the schema.                                                                  |
+| port   | integer | Port     | No       | Port of the Exasol server. Defaults to 8563.                                           |
+| schema | string  | Schema   | No       | Name of the schema.                                                                    |
 
 ### Amazon Glue
+
+[AWS Glue](https://aws.amazon.com/glue/) is a serverless data integration service. Its Data Catalog holds the table definitions and schema metadata describing data stored in Amazon S3 and other sources.
 
 | Key      | Type   | UX Label | Required | Description                                                                                           |
 | -------- | ------ | -------- | -------- | ----------------------------------------------------------------------------------------------------- |
@@ -213,17 +227,19 @@ An Exasol cluster runs a single database and the schema is the namespace, so the
 | host     | string  | Host     | Yes      | The host to the Impala server.                    |
 | port     | integer | Port     | No       | The port to the Impala server. Defaults to 21050. |
 
-### IBM Informix and HCL Informix
+### HCL Informix and IBM Informix
 
-[IBM Informix](https://www.ibm.com/products/informix) is a high performance, always-on, highly scalable and easily embeddable enterprise-class database optimized for the most demanding transactional and analytics workloads. As an object-relational engine, IBM Informix seamlessly integrates the best of relational and object-oriented capabilities enabling the flexible modeling of complex data structures and relationships.
+[HCL Informix](https://www.hcl-software.com/informix) and [IBM Informix](https://www.ibm.com/products/informix) are high performance, always-on, highly scalable and easily embeddable enterprise-class databases optimized for the most demanding transactional and analytics workloads. As object-relational engines, HCL Informix and IBM Informix seamlessly integrate the best of relational and object-oriented capabilities, enabling the flexible modeling of complex data structures and relationships.
 
-| Key      | Type    | UX Label | Required | Description                                        |
-| -------- | ------- | -------- | -------- | -------------------------------------------------- |
-| database | string  | Database | Yes      | The name of the database.                          |
-| host     | string  | Host     | Yes      | The host to the Informix server.                   |
-| port     | integer | Port     | No       | The port to the Informix server. Defaults to 9088. |
+| Key      | Type    | UX Label | Required | Description                                                             |
+| -------- | ------- | -------- | -------- | ----------------------------------------------------------------------- |
+| database | string  | Database | Yes      | The name of the database.                                               |
+| host     | string  | Host     | Yes      | The host to the HCL Informix and IBM Informix server.                   |
+| port     | integer | Port     | No       | The port to the HCL Informix and IBM Informix server. Defaults to 9088. |
 
 ### Kafka Server
+
+[Apache Kafka](https://kafka.apache.org/) is an open-source distributed event streaming platform used for high-performance data pipelines, streaming analytics, and event-driven applications.
 
 | Key      | Type   | UX Label | Required | Description                                                                                           |
 | -------- | ------ | -------- | -------- | ----------------------------------------------------------------------------------------------------- |
@@ -232,6 +248,8 @@ An Exasol cluster runs a single database and the schema is the namespace, so the
 | host     | string | Host     | Yes      | The bootstrap server of the kafka cluster.                                                            |
 
 ### Amazon Kinesis
+
+[Amazon Kinesis Data Streams](https://aws.amazon.com/kinesis/) is a serverless streaming data service for collecting, processing, and analyzing large streams of records in real time.
 
 | Key      | Type   | UX Label | Required | Description                                                                                           |
 | -------- | ------ | -------- | -------- | ----------------------------------------------------------------------------------------------------- |
@@ -242,6 +260,8 @@ An Exasol cluster runs a single database and the schema is the namespace, so the
 
 ### Local Files
 
+A local server describes data stored as one or more files on the local file system, addressed by a relative or absolute path. It is typically used for development, testing, and small datasets.
+
 | Key      | Type   | UX Label | Required | Description                                                                                           |
 | -------- | ------ | -------- | -------- | ----------------------------------------------------------------------------------------------------- |
 | encoding | string | Encoding | No       | Expected character encoding of the payload, e.g. UTF-8, ISO-8859-1, ASCII, UTF-16. Defaults to UTF-8. |
@@ -250,6 +270,8 @@ An Exasol cluster runs a single database and the schema is the namespace, so the
 
 ### MySQL Server
 
+[MySQL](https://www.mysql.com/) is an open-source relational database management system, widely used for transactional and web applications.
+
 | Key      | Type    | UX Label | Required | Description                                     |
 | -------- | ------- | -------- | -------- | ----------------------------------------------- |
 | database | string  | Database | Yes      | The name of the database.                       |
@@ -257,6 +279,8 @@ An Exasol cluster runs a single database and the schema is the namespace, so the
 | port     | integer | Port     | No       | The port of the MySql server. Defaults to 3306. |
 
 ### Oracle
+
+[Oracle Database](https://www.oracle.com/database/) is a multi-model relational database management system used for transactional and analytical enterprise workloads. Clients connect to a named service rather than directly to a database.
 
 | Key         | Type    | UX Label     | Required | Description                    |
 | ----------- | ------- | ------------ | -------- | ------------------------------ |
@@ -276,6 +300,8 @@ An Exasol cluster runs a single database and the schema is the namespace, so the
 | schema   | string  | Schema   | No       | The name of the schema in the database.              |
 
 ### Presto Server
+
+[Presto](https://prestodb.io/) is an open-source distributed SQL query engine for running interactive analytic queries against data sources of any size, from gigabytes to petabytes.
 
 | Key     | Type   | UX Label | Required | Description                   |
 | ------- | ------ | -------- | -------- | ----------------------------- |
@@ -339,6 +365,8 @@ Secure File Transfer Protocol (SFTP) is a network protocol that enables secure a
 
 ### Snowflake
 
+[Snowflake](https://www.snowflake.com/) is a fully managed cloud data platform that separates storage from compute, where compute is provided by virtual warehouses that can be sized and scaled independently.
+
 | Key       | Type    | UX Label  | Required | Description                                                                 |
 | --------- | ------- | --------- | -------- | --------------------------------------------------------------------------- |
 | account   | string  | Account   | Yes      | The Snowflake account used by the server.                                   |
@@ -361,6 +389,8 @@ Secure File Transfer Protocol (SFTP) is a network protocol that enables secure a
 
 ### Synapse Server
 
+[Azure Synapse Analytics](https://azure.microsoft.com/en-us/products/synapse-analytics) is the Microsoft Azure analytics service that brings together enterprise data warehousing and big data analytics.
+
 | Key      | Type    | UX Label | Required | Description                     |
 | -------- | ------- | -------- | -------- | ------------------------------- |
 | database | string  | Database | Yes      | The name of the database.       |
@@ -368,6 +398,8 @@ Secure File Transfer Protocol (SFTP) is a network protocol that enables secure a
 | port     | integer | Port     | Yes      | The port of the Synapse server. |
 
 ### Trino Server
+
+[Trino](https://trino.io/) is an open-source distributed SQL query engine designed to query large datasets across one or more heterogeneous data sources.
 
 | Key     | Type    | UX Label | Required | Description                             |
 | ------- | ------- | -------- | -------- | --------------------------------------- |
@@ -377,6 +409,8 @@ Secure File Transfer Protocol (SFTP) is a network protocol that enables secure a
 | schema  | string  | Schema   | Yes      | The name of the schema in the database. |
 
 ### Vertica Server
+
+[Vertica](https://docs.vertica.com/) is a column-oriented, massively parallel processing (MPP) analytical database for large-scale data warehousing.
 
 | Key      | Type    | UX Label | Required | Description                     |
 | -------- | ------- | -------- | -------- | ------------------------------- |
@@ -396,6 +430,8 @@ Actian Zen (formerly Btrieve, later named Pervasive PSQL until version 13) is an
 | port     | integer | Port     | No       | Zen server SQL connections port. Defaults to 1583. |
 
 ### Custom Server
+
+A custom server describes any technology that does not have a dedicated type in ODCS yet. It accepts the union of the properties defined by the other server types, so connection details can still be expressed in a structured way.
 
 | Key         | Type    | UX Label          | Required | Description                                                                                           |
 | ----------- | ------- | ----------------- | -------- | ----------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
Consistency pass over [`docs/infrastructure-servers.md`](https://github.com/bitol-io/open-data-contract-standard/blob/dev-v3.2.0/docs/infrastructure-servers.md). Docs only — no schema change.

## 1. Every server type now has a definition

18 of the 36 server sections went straight from the heading to the property table, while the other 18 opened with a one-line definition of the technology. Added the missing ones in the existing style (product name linked to the vendor/project page):

API Server · Azure Server · Databricks · IBM Db2 · Denodo · Dremio · Amazon Glue · Kafka · Amazon Kinesis · Local Files · MySQL · Oracle · Presto · Snowflake · Synapse · Trino · Vertica · Custom Server

Three of these describe a concept rather than a product, so they have no link: **API Server**, **Local Files**, and **Custom Server**.

## 2. Informix is always spelled out

Always **HCL Informix and IBM Informix**, never bare "Informix":

- heading: `IBM Informix and HCL Informix` → `HCL Informix and IBM Informix`
- intro: now links both [HCL Informix](https://www.hcl-software.com/informix) and [IBM Informix](https://www.ibm.com/products/informix) (it previously named and linked IBM only)
- the `host` and `port` descriptions, which said "the Informix server"

The lowercase `informix` in the `type` value list is the schema enum value and is left untouched.

## 3. Table alignment

Re-aligned the three tables whose pipes had drifted — Common Server Properties, Exasol, and Informix. Whitespace only, no content change.

No cross-references pointed at the old `#ibm-informix-and-hcl-informix` anchor, so the heading rename breaks no links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)