### PR TITLE
feat(rfc-0057): add `teradata` server type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,10 @@ RFCs targeting v3.2.0 are tracked under [`tsc/rfcs/`](https://github.com/bitol-i
   * New `exasol` server `type` describing data served from Exasol, an in-memory MPP analytics database, with required `host` plus optional `port` (defaults to `8563`) and `schema`.
   * No `database` field: an Exasol cluster runs a single database and the schema is the namespace. `host` may be a cluster connection range, e.g. `n11..14.acme.com`.
   * Non-breaking: adds a new optional server type.
+* **Adds** Teradata server type ([RFC 0057](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0057-teradata-server-type.md)):
+  * New `teradata` server `type` describing data served from Teradata Vantage, with required `host` plus optional `port` (defaults to `1025`) and `database`.
+  * No `schema` field: in Teradata, the database is the namespace.
+  * Non-breaking: adds a new optional server type.
 * **Changes** to Servers:
   * Add optional Athena Server `workgroup` field and fix `stagingDir` to be optional in schema.
 

--- a/docs/examples/server/teradata-server.odcs.yaml
+++ b/docs/examples/server/teradata-server.odcs.yaml
@@ -1,0 +1,25 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Demonstrates RFC-0057: the `teradata` server type for Teradata Vantage, an
+# enterprise data warehouse. In Teradata the database is the namespace, so there
+# is no `schema` field.
+
+version: 1.0.0
+apiVersion: v3.2.0
+kind: DataContract
+id: 3b7d1c58-2f94-4a06-8e1b-9c5a0d4f7e23
+status: active
+servers:
+  - server: prod
+    type: teradata
+    host: teradata.acme.com
+    port: 1025
+    database: SALES
+schema:
+  - name: sales
+    physicalType: table
+    properties:
+      - name: sale_id
+        logicalType: string
+        required: true

--- a/docs/infrastructure-servers.md
+++ b/docs/infrastructure-servers.md
@@ -48,7 +48,7 @@ servers:
 | id               | string | ID                | No       | A unique identifier used to reduce the risk of collisions, such as a UUID.                                                                                                                                                                                                                                                        |
 | roles            | array  | Roles             | No       | List of roles that have access to the server. Check [roles](./roles.md) section for more details.                                                                                                                                                                                                                                 |
 | server           | string | Server            | Yes      | Identifier of the server.                                                                                                                                                                                                                                                                                                         |
-| type             | string | Type              | Yes      | Type of the server. Can be one of: api, athena, azure, bigquery, clickhouse, cloudsql, custom, databricks, db2, denodo, dremio, duckdb, exasol, glue, hive, impala, informix, kafka, kinesis, local, mysql, oracle, postgres, postgresql, presto, pubsub, redshift, s3, sftp, snowflake, sqlserver, synapse, trino, vertica, zen. |
+| type             | string | Type              | Yes      | Type of the server. Can be one of: api, athena, azure, bigquery, clickhouse, cloudsql, custom, databricks, db2, denodo, dremio, duckdb, exasol, glue, hive, impala, informix, kafka, kinesis, local, mysql, oracle, postgres, postgresql, presto, pubsub, redshift, s3, sftp, snowflake, sqlserver, synapse, teradata, trino, vertica, zen. |
 | customProperties | array  | Custom Properties | No       | Custom properties that are not part of the standard.                                                                                                                                                                                                                                                                              |
 
 ## Specific Server Properties
@@ -394,6 +394,18 @@ Secure File Transfer Protocol (SFTP) is a network protocol that enables secure a
 | database | string  | Database | Yes      | The name of the database.       |
 | host     | string  | Host     | Yes      | The host of the Synapse server. |
 | port     | integer | Port     | Yes      | The port of the Synapse server. |
+
+### Teradata
+
+[Teradata Vantage](https://www.teradata.com/) is a widely used enterprise data warehouse for large-scale analytics. Added in ODCS v3.2.0 ([RFC 0057](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0057-teradata-server-type.md)).
+
+In Teradata, the database is the namespace, so there is no `schema` field.
+
+| Key      | Type    | UX Label | Required | Description                                     |
+| -------- | ------- | -------- | -------- | ----------------------------------------------- |
+| database | string  | Database | No       | Name of the database.                           |
+| host     | string  | Host     | Yes      | Host of the Teradata server.                    |
+| port     | integer | Port     | No       | Port of the Teradata server. Defaults to 1025.  |
 
 ### Trino Server
 

--- a/schema/odcs-json-schema-latest.json
+++ b/schema/odcs-json-schema-latest.json
@@ -239,7 +239,7 @@
             "api", "athena", "azure", "bigquery", "clickhouse", "databricks", "denodo", "dremio",
             "duckdb", "exasol", "glue", "hana", "cloudsql", "db2", "hive", "iceberg", "impala", "informix", "kafka", "kinesis", "local",
             "mysql", "oracle", "postgresql", "postgres", "presto", "pubsub",
-            "redshift", "s3", "sftp", "snowflake", "sqlserver", "synapse", "trino", "vertica", "zen", "custom"
+            "redshift", "s3", "sftp", "snowflake", "sqlserver", "synapse", "teradata", "trino", "vertica", "zen", "custom"
           ]
         },
         "description": {
@@ -716,6 +716,19 @@
           },
           "then": {
             "$ref": "#/$defs/ServerSource/SynapseServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "teradata"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/TeradataServer"
           }
         },
         {
@@ -1797,6 +1810,34 @@
           "host",
           "port",
           "database"
+        ]
+      },
+      "TeradataServer": {
+        "type": "object",
+        "title": "TeradataServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "Host of the Teradata server.",
+            "examples": [
+              "teradata.acme.com"
+            ]
+          },
+          "port": {
+            "$ref": "#/$defs/Port",
+            "description": "Port of the Teradata server.",
+            "default": 1025,
+            "examples": [
+              1025
+            ]
+          },
+          "database": {
+            "type": "string",
+            "description": "Name of the database."
+          }
+        },
+        "required": [
+          "host"
         ]
       },
       "TrinoServer": {

--- a/schema/odcs-json-schema-v3.2.0.json
+++ b/schema/odcs-json-schema-v3.2.0.json
@@ -238,7 +238,7 @@
             "api", "athena", "azure", "bigquery", "clickhouse", "databricks", "denodo", "dremio",
             "duckdb", "exasol", "glue", "hana", "cloudsql", "db2", "hive", "iceberg", "impala", "informix", "kafka", "kinesis", "local",
             "mysql", "oracle", "postgresql", "postgres", "presto", "pubsub",
-            "redshift", "s3", "sftp", "snowflake", "sqlserver", "synapse", "trino", "vertica", "zen", "custom"
+            "redshift", "s3", "sftp", "snowflake", "sqlserver", "synapse", "teradata", "trino", "vertica", "zen", "custom"
           ]
         },
         "description": {
@@ -715,6 +715,19 @@
           },
           "then": {
             "$ref": "#/$defs/ServerSource/SynapseServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "teradata"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/TeradataServer"
           }
         },
         {
@@ -1796,6 +1809,34 @@
           "host",
           "port",
           "database"
+        ]
+      },
+      "TeradataServer": {
+        "type": "object",
+        "title": "TeradataServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "Host of the Teradata server.",
+            "examples": [
+              "teradata.acme.com"
+            ]
+          },
+          "port": {
+            "$ref": "#/$defs/Port",
+            "description": "Port of the Teradata server.",
+            "default": 1025,
+            "examples": [
+              1025
+            ]
+          },
+          "database": {
+            "type": "string",
+            "description": "Name of the database."
+          }
+        },
+        "required": [
+          "host"
         ]
       },
       "TrinoServer": {

--- a/src/script/negative-tests/teradata-missing-host.odcs.yaml
+++ b/src/script/negative-tests/teradata-missing-host.odcs.yaml
@@ -1,0 +1,19 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# RFC-0057 negative test: a `teradata` server requires `host`. Here `host` is
+# omitted, so the schema MUST reject this contract.
+
+version: 1.0.0
+apiVersion: v3.2.0
+kind: DataContract
+id: 4e8c2a19-6b03-4d75-9f28-1a3b6c8d0e54
+status: active
+servers:
+  - server: prod
+    type: teradata
+    port: 1025
+    database: SALES
+schema:
+  - name: sales
+    physicalType: table


### PR DESCRIPTION
Applies [RFC-0057](https://github.com/bitol-io/tsc/blob/rfc-0058-exasol/rfcs/0057-teradata-server-type.md) to ODCS v3.2.0: a new `teradata` server type for Teradata Vantage.

## Fields

| Key | Type | Required | Description |
| --- | --- | --- | --- |
| host | string | Yes | Host of the Teradata server. |
| port | integer | No | Port of the Teradata server. Defaults to 1025. |
| database | string | No | Name of the database. |

No `schema` field: in Teradata, the database is the namespace.

## Changes

* Both schema files updated in lockstep (`odcs-json-schema-latest.json`, `odcs-json-schema-v3.2.0.json`): enum value, conditional dispatch, and the `TeradataServer` definition.
* `port` uses the shared `#/$defs/Port` definition from RFC-0050, so it also accepts a variable reference such as `${DB_PORT}`.
* Docs section in `infrastructure-servers.md`, plus `teradata` added to the server `type` list.
* Positive example `docs/examples/server/teradata-server.odcs.yaml`.
* Negative test `src/script/negative-tests/teradata-missing-host.odcs.yaml` (missing `host` is rejected).
* CHANGELOG entry.

Non-breaking: adds a new optional server type.

## Validation

`validate-examples.sh` and `validate-negative.sh` pass locally against both `v3.2.0` and `latest`. The negative test is rejected for the intended reason (`must have required property 'host'`).

## Note

The RFC still has an empty Decision section, so this needs TSC approval before merge.