### PR TITLE
Merge dev-v3.2.0 into dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,10 @@ RFCs targeting v3.2.0 are tracked under [`tsc/rfcs/`](https://github.com/bitol-i
   * New `exasol` server `type` describing data served from Exasol, an in-memory MPP analytics database, with required `host` plus optional `port` (defaults to `8563`) and `schema`.
   * No `database` field: an Exasol cluster runs a single database and the schema is the namespace. `host` may be a cluster connection range, e.g. `n11..14.acme.com`.
   * Non-breaking: adds a new optional server type.
+* **Adds** Teradata server type ([RFC 0057](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0057-teradata-server-type.md)):
+  * New `teradata` server `type` describing data served from Teradata Vantage, with required `host` plus optional `port` (defaults to `1025`) and `database`.
+  * No `schema` field: in Teradata, the database is the namespace.
+  * Non-breaking: adds a new optional server type.
 * **Changes** to Servers:
   * Add optional Athena Server `workgroup` field and fix `stagingDir` to be optional in schema.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,15 @@ RFCs targeting v3.2.0 are tracked under [`tsc/rfcs/`](https://github.com/bitol-i
   * New `teradata` server `type` describing data served from Teradata Vantage, with required `host` plus optional `port` (defaults to `1025`) and `database`.
   * No `schema` field: in Teradata, the database is the namespace.
   * Non-breaking: adds a new optional server type.
+* **Adds** Actian server types ([RFC 0059](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0059-actian-server-types.md)):
+  * New `ingres` server `type` (Actian Ingres, OLTP RDBMS) with required `database` and `host` plus optional `port` (defaults to `21064`).
+  * New `vectorwise` server `type` (Actian Analytics Engine, columnar analytical DBMS) with required `database` and `host` plus optional `port` (defaults to `21064`).
+  * New `versant` server `type` (Actian NoSQL Database, object DBMS) with required `database` plus optional `host` (defaults to `localhost`) and `port` (defaults to `5019`).
+  * New `poet` server `type` (Actian NoSQL FastObjects, object DBMS) with required `database` plus optional `host` (defaults to `LOCAL`, the in-process embedded engine) and `port` (defaults to `6001`).
+  * New synonyms: `fastobjects` for `poet` and `btrieve` for `zen` — same fields, same definitions, neither original value deprecated, as `postgresql` and `postgres` already share `PostgresServer`.
+  * Establishes the naming convention that a server `type` value uses the name the product carried when it was created, in lowercase, since enum values are permanent and marketing names are not.
+  * No `schema` field on any of the four: for `ingres` and `vectorwise` the namespace is the table owner resolved from the connecting user; the two object databases have no SQL schema namespace.
+  * Non-breaking: adds four optional server types and two synonyms. No existing value changes meaning.
 * **Changes** to Servers:
   * Add optional Athena Server `workgroup` field and fix `stagingDir` to be optional in schema.
 

--- a/docs/examples/server/actian-servers.odcs.yaml
+++ b/docs/examples/server/actian-servers.odcs.yaml
@@ -1,0 +1,84 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Demonstrates RFC-0059: the Actian server types. `ingres` (Actian Ingres) and
+# `vectorwise` (Actian Analytics Engine) are SQL engines whose namespace is the
+# table owner, so neither carries a `schema` field. `versant` (Actian NoSQL
+# Database) and `poet` (Actian NoSQL FastObjects) are object databases whose
+# classes are scoped by the database. `fastobjects` is a synonym of `poet` and
+# `btrieve` is a synonym of `zen`; both spellings are valid and neither original
+# value is deprecated.
+
+version: 1.0.0
+apiVersion: v3.2.0
+kind: DataContract
+id: 8f2c4b16-3e57-4d90-a1c8-5b7e0d2f9a64
+status: active
+servers:
+  # Actian Ingres — order-entry OLTP system of record.
+  - server: ingres-prod
+    type: ingres
+    description: Order-entry OLTP system of record
+    environment: prod
+    host: ingres01.acme.com
+    port: 21064
+    database: orders
+    roles:
+      - role: acme_orders_ro
+        access: read
+      - role: acme_orders_rw
+        access: write
+
+  # Actian Analytics Engine — columnar serving layer, non-default installation.
+  - server: vector-preprod
+    type: vectorwise
+    description: Columnar serving layer for the sales data product
+    environment: preprod
+    host: vector02.acme.com
+    port: 21164
+    database: sales_mart
+
+  # Actian NoSQL Database — policy administration object store.
+  - server: versant-prod
+    type: versant
+    description: Policy administration OLTP object store
+    environment: prod
+    host: nosql01.acme.com
+    port: 5019
+    database: policies
+    roles:
+      - role: acme_policies_ro
+        access: read
+
+  # Actian NoSQL FastObjects, embedded: no host, so the in-process engine.
+  - server: fastobjects-device
+    type: poet
+    description: On-device telemetry store
+    environment: dev
+    database: telemetry
+
+  # The same engine addressed by its `fastobjects` synonym, client/server.
+  - server: fastobjects-prod
+    type: fastobjects
+    description: Parts catalog for the CAD workstations
+    environment: prod
+    host: fastobjects.acme.com
+    port: 6001
+    database: parts_catalog
+
+  # Actian Zen addressed by its `btrieve` synonym.
+  - server: zen-prod
+    type: btrieve
+    description: Embedded inventory store
+    environment: prod
+    host: zen.acme.com
+    database: inventory
+schema:
+  - name: orders
+    physicalType: table
+    properties:
+      - name: order_id
+        logicalType: string
+        required: true
+      - name: order_total
+        logicalType: number

--- a/docs/examples/server/teradata-server.odcs.yaml
+++ b/docs/examples/server/teradata-server.odcs.yaml
@@ -1,0 +1,25 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Demonstrates RFC-0057: the `teradata` server type for Teradata Vantage, an
+# enterprise data warehouse. In Teradata the database is the namespace, so there
+# is no `schema` field.
+
+version: 1.0.0
+apiVersion: v3.2.0
+kind: DataContract
+id: 3b7d1c58-2f94-4a06-8e1b-9c5a0d4f7e23
+status: active
+servers:
+  - server: prod
+    type: teradata
+    host: teradata.acme.com
+    port: 1025
+    database: SALES
+schema:
+  - name: sales
+    physicalType: table
+    properties:
+      - name: sale_id
+        logicalType: string
+        required: true

--- a/docs/infrastructure-servers.md
+++ b/docs/infrastructure-servers.md
@@ -48,7 +48,7 @@ servers:
 | id               | string | ID                | No       | A unique identifier used to reduce the risk of collisions, such as a UUID.                                                                                                                                                                                                                                                        |
 | roles            | array  | Roles             | No       | List of roles that have access to the server. Check [roles](./roles.md) section for more details.                                                                                                                                                                                                                                 |
 | server           | string | Server            | Yes      | Identifier of the server.                                                                                                                                                                                                                                                                                                         |
-| type             | string | Type              | Yes      | Type of the server. Can be one of: api, athena, azure, bigquery, clickhouse, cloudsql, custom, databricks, db2, denodo, dremio, duckdb, exasol, glue, hive, impala, informix, kafka, kinesis, local, mysql, oracle, postgres, postgresql, presto, pubsub, redshift, s3, sftp, snowflake, sqlserver, synapse, trino, vertica, zen. |
+| type             | string | Type              | Yes      | Type of the server. Can be one of: api, athena, azure, bigquery, clickhouse, cloudsql, custom, databricks, db2, denodo, dremio, duckdb, exasol, glue, hive, impala, informix, kafka, kinesis, local, mysql, oracle, postgres, postgresql, presto, pubsub, redshift, s3, sftp, snowflake, sqlserver, synapse, teradata, trino, vertica, zen. |
 | customProperties | array  | Custom Properties | No       | Custom properties that are not part of the standard.                                                                                                                                                                                                                                                                              |
 
 ## Specific Server Properties
@@ -394,6 +394,18 @@ Secure File Transfer Protocol (SFTP) is a network protocol that enables secure a
 | database | string  | Database | Yes      | The name of the database.       |
 | host     | string  | Host     | Yes      | The host of the Synapse server. |
 | port     | integer | Port     | Yes      | The port of the Synapse server. |
+
+### Teradata
+
+[Teradata Vantage](https://www.teradata.com/) is a widely used enterprise data warehouse for large-scale analytics. Added in ODCS v3.2.0 ([RFC 0057](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0057-teradata-server-type.md)).
+
+In Teradata, the database is the namespace, so there is no `schema` field.
+
+| Key      | Type    | UX Label | Required | Description                                     |
+| -------- | ------- | -------- | -------- | ----------------------------------------------- |
+| database | string  | Database | No       | Name of the database.                           |
+| host     | string  | Host     | Yes      | Host of the Teradata server.                    |
+| port     | integer | Port     | No       | Port of the Teradata server. Defaults to 1025.  |
 
 ### Trino Server
 

--- a/docs/infrastructure-servers.md
+++ b/docs/infrastructure-servers.md
@@ -48,7 +48,7 @@ servers:
 | id               | string | ID                | No       | A unique identifier used to reduce the risk of collisions, such as a UUID.                                                                                                                                                                                                                                                        |
 | roles            | array  | Roles             | No       | List of roles that have access to the server. Check [roles](./roles.md) section for more details.                                                                                                                                                                                                                                 |
 | server           | string | Server            | Yes      | Identifier of the server.                                                                                                                                                                                                                                                                                                         |
-| type             | string | Type              | Yes      | Type of the server. Can be one of: api, athena, azure, bigquery, clickhouse, cloudsql, custom, databricks, db2, denodo, dremio, duckdb, exasol, glue, hive, impala, informix, kafka, kinesis, local, mysql, oracle, postgres, postgresql, presto, pubsub, redshift, s3, sftp, snowflake, sqlserver, synapse, teradata, trino, vertica, zen. |
+| type             | string | Type              | Yes      | Type of the server. Can be one of: api, athena, azure, bigquery, btrieve, clickhouse, cloudsql, custom, databricks, db2, denodo, dremio, duckdb, exasol, fastobjects, glue, hive, impala, informix, ingres, kafka, kinesis, local, mysql, oracle, poet, postgres, postgresql, presto, pubsub, redshift, s3, sftp, snowflake, sqlserver, synapse, teradata, trino, vectorwise, versant, vertica, zen. |
 | customProperties | array  | Custom Properties | No       | Custom properties that are not part of the standard.                                                                                                                                                                                                                                                                              |
 
 ## Specific Server Properties
@@ -235,6 +235,18 @@ An Exasol cluster runs a single database and the schema is the namespace, so the
 | host     | string  | Host     | Yes      | The host to the HCL Informix and IBM Informix server.                   |
 | port     | integer | Port     | No       | The port to the HCL Informix and IBM Informix server. Defaults to 9088. |
 
+### Actian Ingres
+
+[Actian Ingres](https://www.actian.com/databases/ingres/) is an enterprise relational database for transactional (OLTP) and hybrid workloads. Added in ODCS v3.2.0 ([RFC 0059](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0059-actian-server-types.md)).
+
+The namespace inside an Ingres database is the table owner, resolved from the connecting user, so there is no `schema` field. `port` is derived from the Ingres installation identifier and defaults to the `II7` installation; set it explicitly when a host runs more than one installation.
+
+| Key      | Type    | UX Label | Required | Description                                                                                              |
+| -------- | ------- | -------- | -------- | -------------------------------------------------------------------------------------------------------- |
+| database | string  | Database | Yes      | Database name to connect to on the Ingres instance.                                                      |
+| host     | string  | Host     | Yes      | Hostname or IP address of the Ingres server.                                                             |
+| port     | integer | Port     | No       | Connection port for the Ingres Data Access Server (DAS) / SQL connections. Defaults to 21064.            |
+
 ### Kafka Server
 
 [Apache Kafka](https://kafka.apache.org/) is an open-source distributed event streaming platform used for high-performance data pipelines, streaming analytics, and event-driven applications.
@@ -285,6 +297,20 @@ A local server describes data stored as one or more files on the local file syst
 | host        | string  | Host         | Yes      | The host to the Oracle server  |
 | port        | integer | Port         | Yes      | The port to the Oracle server. |
 | serviceName | string  | Service Name | Yes      | The name of the service.       |
+
+### Actian NoSQL FastObjects
+
+[Actian NoSQL FastObjects](https://www.actian.com/databases/nosql/) is an object database management system (ODBMS) for embedded and client/server applications. Created as POET, renamed FastObjects in 2001. Added in ODCS v3.2.0 ([RFC 0059](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0059-actian-server-types.md)).
+
+The `type` value is the creation name, `poet`. `fastobjects` is an accepted synonym: same fields, same validation, neither value deprecated.
+
+An object database has no SQL schema namespace — classes are scoped by the database — so there is no `schema` field. `LOCAL` is a literal FastObjects sentinel rather than a hostname: it selects the in-process embedded engine, so one `host` field covers both the embedded and the client/server deployment.
+
+| Key      | Type    | UX Label | Required | Description                                                                                     |
+| -------- | ------- | -------- | -------- | ------------------------------------------------------------------------------------------------- |
+| database | string  | Database | Yes      | Database name to connect to on the FastObjects instance.                                        |
+| host     | string  | Host     | No       | Hostname or IP address of the FastObjects server. Defaults to `LOCAL`, the embedded engine.     |
+| port     | integer | Port     | No       | Connection port for FastObjects connections. Defaults to 6001.                                  |
 
 ### PostgreSQL
 
@@ -418,6 +444,34 @@ In Teradata, the database is the namespace, so there is no `schema` field.
 | port    | integer | Port     | Yes      | The Trino port.                         |
 | schema  | string  | Schema   | Yes      | The name of the schema in the database. |
 
+### Actian Analytics Engine
+
+The [Actian Analytics Engine](https://www.actian.com/databases/analytics-engine/) is a columnar analytical DBMS for high-speed SQL and big data processing. Created as VectorWise, later named Actian Vector. Added in ODCS v3.2.0 ([RFC 0059](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0059-actian-server-types.md)).
+
+The `type` value is the creation name, `vectorwise`. Tooling should display the Actian Analytics Engine label and write the enum value.
+
+The namespace inside a database is the table owner, resolved from the connecting user, so there is no `schema` field. `port` is derived from the Ingres installation identifier; set it explicitly when a host runs more than one installation.
+
+| Key      | Type    | UX Label | Required | Description                                                                          |
+| -------- | ------- | -------- | -------- | -------------------------------------------------------------------------------------- |
+| database | string  | Database | Yes      | Database name to connect to on the Analytics Engine server.                          |
+| host     | string  | Host     | Yes      | Hostname or IP address of the Analytics Engine server.                               |
+| port     | integer | Port     | No       | Connection port for the Data Access Server (DAS) / SQL connections. Defaults to 21064. |
+
+### Actian NoSQL Database
+
+[Actian NoSQL Database](https://www.actian.com/databases/nosql/) is an object database management system (ODBMS) for mission-critical OLTP. Created as the Versant Object Database. Added in ODCS v3.2.0 ([RFC 0059](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0059-actian-server-types.md)).
+
+The `type` value is the creation name, `versant`. Tooling should display the Actian NoSQL Database label and write the enum value.
+
+An object database has no SQL schema namespace — classes are scoped by the database — so there is no `schema` field.
+
+| Key      | Type    | UX Label | Required | Description                                                                |
+| -------- | ------- | -------- | -------- | ---------------------------------------------------------------------------- |
+| database | string  | Database | Yes      | Database name to connect to on the NoSQL Database instance.                |
+| host     | string  | Host     | No       | Hostname or IP address of the NoSQL Database server. Defaults to `localhost`. |
+| port     | integer | Port     | No       | Connection port for Actian NoSQL Database connections. Defaults to 5019.   |
+
 ### Vertica Server
 
 [Vertica](https://docs.vertica.com/) is a column-oriented, massively parallel processing (MPP) analytical database for large-scale data warehousing.
@@ -432,6 +486,8 @@ In Teradata, the database is the namespace, so there is no `schema` field.
 ### Actian Zen Server
 
 Actian Zen (formerly Btrieve, later named Pervasive PSQL until version 13) is an ACID-compliant, zero-DBA, embedded, nano-footprint, multi-model, Multi-Platform database management system (DBMS).
+
+Since ODCS v3.2.0 ([RFC 0059](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0059-actian-server-types.md)), `btrieve` is an accepted synonym of `zen`: same fields, same validation, neither value deprecated.
 
 | Key      | Type    | UX Label | Required | Description                                        |
 | -------- | ------- | -------- | -------- | -------------------------------------------------- |

--- a/schema/odcs-json-schema-latest.json
+++ b/schema/odcs-json-schema-latest.json
@@ -236,10 +236,10 @@
           "type": "string",
           "description": "Type of the server.",
           "enum": [
-            "api", "athena", "azure", "bigquery", "clickhouse", "databricks", "denodo", "dremio",
-            "duckdb", "exasol", "glue", "hana", "cloudsql", "db2", "hive", "iceberg", "impala", "informix", "kafka", "kinesis", "local",
-            "mysql", "oracle", "postgresql", "postgres", "presto", "pubsub",
-            "redshift", "s3", "sftp", "snowflake", "sqlserver", "synapse", "teradata", "trino", "vertica", "zen", "custom"
+            "api", "athena", "azure", "bigquery", "btrieve", "clickhouse", "databricks", "denodo", "dremio",
+            "duckdb", "exasol", "fastobjects", "glue", "hana", "cloudsql", "db2", "hive", "iceberg", "impala", "informix", "ingres", "kafka", "kinesis", "local",
+            "mysql", "oracle", "poet", "postgresql", "postgres", "presto", "pubsub",
+            "redshift", "s3", "sftp", "snowflake", "sqlserver", "synapse", "teradata", "trino", "vectorwise", "versant", "vertica", "zen", "custom"
           ]
         },
         "description": {
@@ -313,6 +313,19 @@
           },
           "then": {
             "$ref": "#/$defs/ServerSource/BigQueryServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "btrieve"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/ZenServer"
           }
         },
         {
@@ -397,6 +410,19 @@
           "if": {
             "properties": {
               "type": {
+                "const": "fastobjects"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/PoetServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
                 "const": "glue"
               }
             },
@@ -469,6 +495,19 @@
           },
           "then": {
             "$ref": "#/$defs/ServerSource/InformixServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "ingres"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/IngresServer"
           }
         },
         {
@@ -560,6 +599,19 @@
           },
           "then": {
             "$ref": "#/$defs/ServerSource/OracleServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "poet"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/PoetServer"
           }
         },
         {
@@ -742,6 +794,32 @@
           },
           "then": {
             "$ref": "#/$defs/ServerSource/TrinoServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "vectorwise"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/VectorwiseServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "versant"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/VersantServer"
           }
         },
         {
@@ -1191,6 +1269,38 @@
           "database"
         ]
       },
+      "IngresServer": {
+        "type": "object",
+        "title": "IngresServer",
+        "properties": {
+          "database": {
+            "type": "string",
+            "description": "Database name to connect to on the Ingres instance.",
+            "examples": [
+              "sales"
+            ]
+          },
+          "host": {
+            "type": "string",
+            "description": "Hostname or IP address of the Ingres server.",
+            "examples": [
+              "ingres.acme.com"
+            ]
+          },
+          "port": {
+            "$ref": "#/$defs/Port",
+            "description": "Connection port for the Ingres Data Access Server (DAS) / SQL connections.",
+            "default": 21064,
+            "examples": [
+              21064
+            ]
+          }
+        },
+        "required": [
+          "database",
+          "host"
+        ]
+      },
       "ZenServer": {
         "type": "object",
         "title": "ZenServer",
@@ -1458,6 +1568,39 @@
           "host",
           "port",
           "serviceName"
+        ]
+      },
+      "PoetServer": {
+        "type": "object",
+        "title": "PoetServer",
+        "properties": {
+          "database": {
+            "type": "string",
+            "description": "Database name to connect to on the FastObjects instance.",
+            "examples": [
+              "parts_catalog"
+            ]
+          },
+          "host": {
+            "type": "string",
+            "description": "Hostname or IP address of the FastObjects server. The literal LOCAL selects the in-process embedded engine.",
+            "default": "LOCAL",
+            "examples": [
+              "LOCAL",
+              "fastobjects02.acme.com"
+            ]
+          },
+          "port": {
+            "$ref": "#/$defs/Port",
+            "description": "Connection port for FastObjects connections.",
+            "default": 6001,
+            "examples": [
+              6001
+            ]
+          }
+        },
+        "required": [
+          "database"
         ]
       },
       "PostgresServer": {
@@ -1875,6 +2018,70 @@
           "port",
           "catalog",
           "schema"
+        ]
+      },
+      "VectorwiseServer": {
+        "type": "object",
+        "title": "VectorwiseServer",
+        "properties": {
+          "database": {
+            "type": "string",
+            "description": "Database name to connect to on the Analytics Engine server.",
+            "examples": [
+              "warehouse"
+            ]
+          },
+          "host": {
+            "type": "string",
+            "description": "Hostname or IP address of the Analytics Engine server.",
+            "examples": [
+              "analytics.acme.com"
+            ]
+          },
+          "port": {
+            "$ref": "#/$defs/Port",
+            "description": "Connection port for the Data Access Server (DAS) / SQL connections.",
+            "default": 21064,
+            "examples": [
+              21064
+            ]
+          }
+        },
+        "required": [
+          "database",
+          "host"
+        ]
+      },
+      "VersantServer": {
+        "type": "object",
+        "title": "VersantServer",
+        "properties": {
+          "database": {
+            "type": "string",
+            "description": "Database name to connect to on the NoSQL Database instance.",
+            "examples": [
+              "policies"
+            ]
+          },
+          "host": {
+            "type": "string",
+            "description": "Hostname or IP address of the NoSQL Database server.",
+            "default": "localhost",
+            "examples": [
+              "nosql.acme.com"
+            ]
+          },
+          "port": {
+            "$ref": "#/$defs/Port",
+            "description": "Connection port for Actian NoSQL Database connections.",
+            "default": 5019,
+            "examples": [
+              5019
+            ]
+          }
+        },
+        "required": [
+          "database"
         ]
       },
       "VerticaServer": {

--- a/schema/odcs-json-schema-latest.json
+++ b/schema/odcs-json-schema-latest.json
@@ -239,7 +239,7 @@
             "api", "athena", "azure", "bigquery", "clickhouse", "databricks", "denodo", "dremio",
             "duckdb", "exasol", "glue", "hana", "cloudsql", "db2", "hive", "iceberg", "impala", "informix", "kafka", "kinesis", "local",
             "mysql", "oracle", "postgresql", "postgres", "presto", "pubsub",
-            "redshift", "s3", "sftp", "snowflake", "sqlserver", "synapse", "trino", "vertica", "zen", "custom"
+            "redshift", "s3", "sftp", "snowflake", "sqlserver", "synapse", "teradata", "trino", "vertica", "zen", "custom"
           ]
         },
         "description": {
@@ -716,6 +716,19 @@
           },
           "then": {
             "$ref": "#/$defs/ServerSource/SynapseServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "teradata"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/TeradataServer"
           }
         },
         {
@@ -1797,6 +1810,34 @@
           "host",
           "port",
           "database"
+        ]
+      },
+      "TeradataServer": {
+        "type": "object",
+        "title": "TeradataServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "Host of the Teradata server.",
+            "examples": [
+              "teradata.acme.com"
+            ]
+          },
+          "port": {
+            "$ref": "#/$defs/Port",
+            "description": "Port of the Teradata server.",
+            "default": 1025,
+            "examples": [
+              1025
+            ]
+          },
+          "database": {
+            "type": "string",
+            "description": "Name of the database."
+          }
+        },
+        "required": [
+          "host"
         ]
       },
       "TrinoServer": {

--- a/schema/odcs-json-schema-v3.2.0.json
+++ b/schema/odcs-json-schema-v3.2.0.json
@@ -238,7 +238,7 @@
             "api", "athena", "azure", "bigquery", "clickhouse", "databricks", "denodo", "dremio",
             "duckdb", "exasol", "glue", "hana", "cloudsql", "db2", "hive", "iceberg", "impala", "informix", "kafka", "kinesis", "local",
             "mysql", "oracle", "postgresql", "postgres", "presto", "pubsub",
-            "redshift", "s3", "sftp", "snowflake", "sqlserver", "synapse", "trino", "vertica", "zen", "custom"
+            "redshift", "s3", "sftp", "snowflake", "sqlserver", "synapse", "teradata", "trino", "vertica", "zen", "custom"
           ]
         },
         "description": {
@@ -715,6 +715,19 @@
           },
           "then": {
             "$ref": "#/$defs/ServerSource/SynapseServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "teradata"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/TeradataServer"
           }
         },
         {
@@ -1796,6 +1809,34 @@
           "host",
           "port",
           "database"
+        ]
+      },
+      "TeradataServer": {
+        "type": "object",
+        "title": "TeradataServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "Host of the Teradata server.",
+            "examples": [
+              "teradata.acme.com"
+            ]
+          },
+          "port": {
+            "$ref": "#/$defs/Port",
+            "description": "Port of the Teradata server.",
+            "default": 1025,
+            "examples": [
+              1025
+            ]
+          },
+          "database": {
+            "type": "string",
+            "description": "Name of the database."
+          }
+        },
+        "required": [
+          "host"
         ]
       },
       "TrinoServer": {

--- a/schema/odcs-json-schema-v3.2.0.json
+++ b/schema/odcs-json-schema-v3.2.0.json
@@ -235,10 +235,10 @@
           "type": "string",
           "description": "Type of the server.",
           "enum": [
-            "api", "athena", "azure", "bigquery", "clickhouse", "databricks", "denodo", "dremio",
-            "duckdb", "exasol", "glue", "hana", "cloudsql", "db2", "hive", "iceberg", "impala", "informix", "kafka", "kinesis", "local",
-            "mysql", "oracle", "postgresql", "postgres", "presto", "pubsub",
-            "redshift", "s3", "sftp", "snowflake", "sqlserver", "synapse", "teradata", "trino", "vertica", "zen", "custom"
+            "api", "athena", "azure", "bigquery", "btrieve", "clickhouse", "databricks", "denodo", "dremio",
+            "duckdb", "exasol", "fastobjects", "glue", "hana", "cloudsql", "db2", "hive", "iceberg", "impala", "informix", "ingres", "kafka", "kinesis", "local",
+            "mysql", "oracle", "poet", "postgresql", "postgres", "presto", "pubsub",
+            "redshift", "s3", "sftp", "snowflake", "sqlserver", "synapse", "teradata", "trino", "vectorwise", "versant", "vertica", "zen", "custom"
           ]
         },
         "description": {
@@ -312,6 +312,19 @@
           },
           "then": {
             "$ref": "#/$defs/ServerSource/BigQueryServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "btrieve"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/ZenServer"
           }
         },
         {
@@ -396,6 +409,19 @@
           "if": {
             "properties": {
               "type": {
+                "const": "fastobjects"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/PoetServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
                 "const": "glue"
               }
             },
@@ -468,6 +494,19 @@
           },
           "then": {
             "$ref": "#/$defs/ServerSource/InformixServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "ingres"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/IngresServer"
           }
         },
         {
@@ -559,6 +598,19 @@
           },
           "then": {
             "$ref": "#/$defs/ServerSource/OracleServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "poet"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/PoetServer"
           }
         },
         {
@@ -741,6 +793,32 @@
           },
           "then": {
             "$ref": "#/$defs/ServerSource/TrinoServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "vectorwise"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/VectorwiseServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "versant"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/VersantServer"
           }
         },
         {
@@ -1190,6 +1268,38 @@
           "database"
         ]
       },
+      "IngresServer": {
+        "type": "object",
+        "title": "IngresServer",
+        "properties": {
+          "database": {
+            "type": "string",
+            "description": "Database name to connect to on the Ingres instance.",
+            "examples": [
+              "sales"
+            ]
+          },
+          "host": {
+            "type": "string",
+            "description": "Hostname or IP address of the Ingres server.",
+            "examples": [
+              "ingres.acme.com"
+            ]
+          },
+          "port": {
+            "$ref": "#/$defs/Port",
+            "description": "Connection port for the Ingres Data Access Server (DAS) / SQL connections.",
+            "default": 21064,
+            "examples": [
+              21064
+            ]
+          }
+        },
+        "required": [
+          "database",
+          "host"
+        ]
+      },
       "ZenServer": {
         "type": "object",
         "title": "ZenServer",
@@ -1457,6 +1567,39 @@
           "host",
           "port",
           "serviceName"
+        ]
+      },
+      "PoetServer": {
+        "type": "object",
+        "title": "PoetServer",
+        "properties": {
+          "database": {
+            "type": "string",
+            "description": "Database name to connect to on the FastObjects instance.",
+            "examples": [
+              "parts_catalog"
+            ]
+          },
+          "host": {
+            "type": "string",
+            "description": "Hostname or IP address of the FastObjects server. The literal LOCAL selects the in-process embedded engine.",
+            "default": "LOCAL",
+            "examples": [
+              "LOCAL",
+              "fastobjects02.acme.com"
+            ]
+          },
+          "port": {
+            "$ref": "#/$defs/Port",
+            "description": "Connection port for FastObjects connections.",
+            "default": 6001,
+            "examples": [
+              6001
+            ]
+          }
+        },
+        "required": [
+          "database"
         ]
       },
       "PostgresServer": {
@@ -1874,6 +2017,70 @@
           "port",
           "catalog",
           "schema"
+        ]
+      },
+      "VectorwiseServer": {
+        "type": "object",
+        "title": "VectorwiseServer",
+        "properties": {
+          "database": {
+            "type": "string",
+            "description": "Database name to connect to on the Analytics Engine server.",
+            "examples": [
+              "warehouse"
+            ]
+          },
+          "host": {
+            "type": "string",
+            "description": "Hostname or IP address of the Analytics Engine server.",
+            "examples": [
+              "analytics.acme.com"
+            ]
+          },
+          "port": {
+            "$ref": "#/$defs/Port",
+            "description": "Connection port for the Data Access Server (DAS) / SQL connections.",
+            "default": 21064,
+            "examples": [
+              21064
+            ]
+          }
+        },
+        "required": [
+          "database",
+          "host"
+        ]
+      },
+      "VersantServer": {
+        "type": "object",
+        "title": "VersantServer",
+        "properties": {
+          "database": {
+            "type": "string",
+            "description": "Database name to connect to on the NoSQL Database instance.",
+            "examples": [
+              "policies"
+            ]
+          },
+          "host": {
+            "type": "string",
+            "description": "Hostname or IP address of the NoSQL Database server.",
+            "default": "localhost",
+            "examples": [
+              "nosql.acme.com"
+            ]
+          },
+          "port": {
+            "$ref": "#/$defs/Port",
+            "description": "Connection port for Actian NoSQL Database connections.",
+            "default": 5019,
+            "examples": [
+              5019
+            ]
+          }
+        },
+        "required": [
+          "database"
         ]
       },
       "VerticaServer": {

--- a/src/script/negative-tests/btrieve-missing-host.odcs.yaml
+++ b/src/script/negative-tests/btrieve-missing-host.odcs.yaml
@@ -1,0 +1,20 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# RFC-0059 negative test: `btrieve` is a synonym of `zen` and dispatches to the
+# same ZenServer definition, which requires both `host` and `database`. Here
+# `host` is omitted, so the schema MUST reject this contract — the synonym is
+# validated as strictly as the primary value.
+
+version: 1.0.0
+apiVersion: v3.2.0
+kind: DataContract
+id: 5e719314-6f8a-40c5-d24e-b06fa18c2d59
+status: active
+servers:
+  - server: prod
+    type: btrieve
+    database: inventory
+schema:
+  - name: inventory
+    physicalType: table

--- a/src/script/negative-tests/fastobjects-missing-database.odcs.yaml
+++ b/src/script/negative-tests/fastobjects-missing-database.odcs.yaml
@@ -1,0 +1,21 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# RFC-0059 negative test: `fastobjects` is a synonym of `poet` and dispatches to
+# the same PoetServer definition, which requires `database`. Here `database` is
+# omitted, so the schema MUST reject this contract — the synonym is validated as
+# strictly as the primary value.
+
+version: 1.0.0
+apiVersion: v3.2.0
+kind: DataContract
+id: 4d608203-5e79-4fb4-c13d-af5e907b1c48
+status: active
+servers:
+  - server: prod
+    type: fastobjects
+    host: fastobjects.acme.com
+    port: 6001
+schema:
+  - name: parts_catalog
+    physicalType: table

--- a/src/script/negative-tests/ingres-missing-host.odcs.yaml
+++ b/src/script/negative-tests/ingres-missing-host.odcs.yaml
@@ -1,0 +1,19 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# RFC-0059 negative test: an `ingres` server requires both `database` and
+# `host`. Here `host` is omitted, so the schema MUST reject this contract.
+
+version: 1.0.0
+apiVersion: v3.2.0
+kind: DataContract
+id: 1a3d5f70-2b46-4c81-9e0a-7c2b6d4f8e15
+status: active
+servers:
+  - server: prod
+    type: ingres
+    port: 21064
+    database: orders
+schema:
+  - name: orders
+    physicalType: table

--- a/src/script/negative-tests/teradata-missing-host.odcs.yaml
+++ b/src/script/negative-tests/teradata-missing-host.odcs.yaml
@@ -1,0 +1,19 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# RFC-0057 negative test: a `teradata` server requires `host`. Here `host` is
+# omitted, so the schema MUST reject this contract.
+
+version: 1.0.0
+apiVersion: v3.2.0
+kind: DataContract
+id: 4e8c2a19-6b03-4d75-9f28-1a3b6c8d0e54
+status: active
+servers:
+  - server: prod
+    type: teradata
+    port: 1025
+    database: SALES
+schema:
+  - name: sales
+    physicalType: table

--- a/src/script/negative-tests/vectorwise-missing-database.odcs.yaml
+++ b/src/script/negative-tests/vectorwise-missing-database.odcs.yaml
@@ -1,0 +1,19 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# RFC-0059 negative test: a `vectorwise` server requires both `database` and
+# `host`. Here `database` is omitted, so the schema MUST reject this contract.
+
+version: 1.0.0
+apiVersion: v3.2.0
+kind: DataContract
+id: 2b4e6081-3c57-4d92-af1b-8d3c7e5f9a26
+status: active
+servers:
+  - server: prod
+    type: vectorwise
+    host: analytics.acme.com
+    port: 21064
+schema:
+  - name: sales
+    physicalType: table

--- a/src/script/negative-tests/versant-missing-database.odcs.yaml
+++ b/src/script/negative-tests/versant-missing-database.odcs.yaml
@@ -1,0 +1,20 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# RFC-0059 negative test: a `versant` server requires `database` (`host` and
+# `port` are optional). Here `database` is omitted, so the schema MUST reject
+# this contract.
+
+version: 1.0.0
+apiVersion: v3.2.0
+kind: DataContract
+id: 3c5f7192-4d68-4ea3-b02c-9e4d8f6a0b37
+status: active
+servers:
+  - server: prod
+    type: versant
+    host: nosql01.acme.com
+    port: 5019
+schema:
+  - name: policies
+    physicalType: table


### PR DESCRIPTION
Rollup of the v3.2.0 work that has landed on `dev-v3.2.0` since [#301](https://github.com/bitol-io/open-data-contract-standard/pull/301) merged.

## What it brings

* **Teradata server type** ([#318](https://github.com/bitol-io/open-data-contract-standard/pull/318), [RFC 0057](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0057-teradata-server-type.md)) — `teradata` type, required `host`, optional `port` (default `1025`) and `database`.
* **Actian server types** ([#319](https://github.com/bitol-io/open-data-contract-standard/pull/319), [RFC 0059](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0059-actian-server-types.md)) — `ingres`, `vectorwise`, `versant` and `poet`, plus `fastobjects` as a synonym of `poet` and `btrieve` as a synonym of `zen`.

Both schema files stay in lockstep; every new server type ships with docs, a positive example, and a negative test.

## Merge

Clean merge this time — no conflicts to resolve. `dev` contributed only the sync-main-into-dev merge ([#316](https://github.com/bitol-io/open-data-contract-standard/pull/316)), which does not touch the same regions.

## Validation

`validate-negative.sh` and `validate-examples.sh` both run clean on the merged tree against **both** schema files (`JSON_SCHEMA_VERSION` unset and `=latest`) — four runs, `Total failed=0`, exit 0 each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01An6KmURPXG4Y8uDwd15Roq