### PR TITLE
docs(changelog): mark v3.2.0 as APPROVED

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ image: "https://raw.githubusercontent.com/bitol-io/artwork/main/horizontal/color
 
 This document tracks the history and evolution of the **Open Data Contract Standard**.
 
-# v3.2.0 "Peter Flook" - IN PROGRESS
+# v3.2.0 "Peter Flook" - APPROVED
 
 This release is dedicated to the memory of our friend and longtime contributor **Peter Flook**, whose work shaped many parts of ODCS, from data quality testing to the negative-test suite, schema validation, documentation, and vendor onboarding. We carry his contributions forward in this version and beyond.
 


### PR DESCRIPTION
Change the v3.2.0 changelog heading from "IN PROGRESS" to "APPROVED".

Already committed on `dev-v3.2.0` (85389bc).