### PR TITLE
fix(schema): the map conditional only applies when logicalType is present (#322)

### DIFF
--- a/docs/examples/schema/property-without-logicaltype.odcs.yaml
+++ b/docs/examples/schema/property-without-logicaltype.odcs.yaml
@@ -1,0 +1,33 @@
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+version: 1.0.0
+kind: DataContract
+id: 8f2b1c74-3d9e-4a6b-b0c5-7e1f2a3d4b5c
+apiVersion: v3.2.0
+status: active
+name: property_without_logicaltype
+description:
+  purpose: >-
+    `logicalType` is optional on a schema property. A contract that describes its columns with
+    `physicalType` alone — the common shape when a schema is imported from DDL and the source type
+    has no portable logical equivalent — must validate. Guards the regression fixed alongside this
+    example, where the `logicalType: map` conditional applied to properties that declared no
+    `logicalType` at all and demanded a `map` block from them.
+
+schema:
+  - name: raw_import
+    physicalType: table
+    description: A table described by physical types only, as a DDL import produces.
+    properties:
+      # No logicalType anywhere in this file. That is the whole point of the example.
+      - name: order_id
+        physicalType: bigint
+        primaryKey: true
+        primaryKeyPosition: 1
+        description: Source system identifier, carried through untranslated.
+      - name: vendor_specific_code
+        physicalType: VARCHAR2(30)
+        description: A vendor type with no portable logical equivalent.
+      - name: untyped_passthrough
+        description: Neither a logical nor a physical type is known for this column yet.

--- a/schema/odcs-json-schema-v3.2.0.json
+++ b/schema/odcs-json-schema-v3.2.0.json
@@ -2646,7 +2646,10 @@
               "logicalType": {
                 "const": "map"
               }
-            }
+            },
+            "required": [
+              "logicalType"
+            ]
           },
           "then": {
             "properties": {
@@ -2676,7 +2679,10 @@
               "logicalType": {
                 "const": "vector"
               }
-            }
+            },
+            "required": [
+              "logicalType"
+            ]
           },
           "then": {
             "properties": {


### PR DESCRIPTION
Fixes #322.

## The problem

`$defs/SchemaBaseProperty` gates its per-`logicalType` conditionals like this:

```json
{ "if":   { "properties": { "logicalType": { "const": "map" } } },
  "then": { "properties": { "map": { ... } }, "required": ["map"] } }
```

In JSON Schema, `properties` constrains a key **only if that key is present**. A property with no `logicalType` at all therefore satisfies the `if` vacuously, and for `map` the `then` adds `"required": ["map"]` — so every property that omits `logicalType` is required to carry a map block:

```yaml
apiVersion: v3.2.0
kind: DataContract
id: x
version: 1.0.0
status: active
schema:
  - name: t
    properties:
      - name: c
        physicalType: varchar
```

```
'map' is a required property
```

`logicalType` is optional, and describing a column with `physicalType` alone is the ordinary shape when a schema is imported from DDL and the source type has no portable logical equivalent. So this rejects valid contracts.

## The fix

Add `"required": ["logicalType"]` to the `if`, so the conditional applies only when the key is actually present.

**The rule itself is unchanged.** Declaring `logicalType: map` without a `map` block is still rejected — `src/script/negative-tests/map-missing-block.odcs.yaml` continues to pass, which is what proves the fix narrows *when* the rule fires rather than weakening the rule.

`vector` is guarded the same way, as #322 suggests. Its `then` adds no `required` today, so it is not currently affected; guarding it now means the next `then` that gains one cannot reintroduce this.

## Scope

The same vacuous `if` appears on **every** per-`logicalType` conditional, and on the v3.1.0 schema too. It is harmless everywhere else because those `then` blocks only add `properties` — `map` is the first whose `then` adds a `required`, so it is the first that bites. **v3.1.0 is not affected and is not touched here**, which answers the question asked on #322.

## Why CI did not catch this, and what stops it recurring

`validate-examples.sh` **passes against the unpatched schema** — I checked. None of the 40 example contracts omits `logicalType` on a property, so nothing exercised the path.

This PR adds `docs/examples/schema/property-without-logicaltype.odcs.yaml`, which is:

- **rejected** by the current schema (`'map' is a required property`), and
- **accepted** by the patched one.

So it fails without this fix and passes with it — a real guard rather than another example that happens to pass.

## Verification

| check | result |
|---|---|
| `src/script/validate-examples.sh` | `Total failed=0` (including the new example) |
| `src/script/validate-negative.sh` | `Total failed=0` — every negative case still correctly rejected, `map-missing-block` and `vector-missing-dimensions` included |
| `ajv compile` on the schema | valid |

## A note on the changelog

I have not touched `CHANGELOG.md`: the v3.2.0 section is already stamped `APPROVED`, and how a post-approval schema correction should be recorded is your call rather than something to presume in a PR. Happy to add a line in whatever form you prefer.

---

Context, in the interest of being upfront: this was found downstream while promoting ODCS v3.2.0 to the default in a platform that validates contracts on write, where it would have rejected new contracts. That deployment is currently carrying this same one-key change as a local patch, to be dropped as soon as this lands.