### PR TITLE
fix(schema): apply the map/vector logicalType guard to the latest schema (#322)

### DIFF
--- a/schema/odcs-json-schema-latest.json
+++ b/schema/odcs-json-schema-latest.json
@@ -2647,7 +2647,10 @@
               "logicalType": {
                 "const": "map"
               }
-            }
+            },
+            "required": [
+              "logicalType"
+            ]
           },
           "then": {
             "properties": {
@@ -2677,7 +2680,10 @@
               "logicalType": {
                 "const": "vector"
               }
-            }
+            },
+            "required": [
+              "logicalType"
+            ]
           },
           "then": {
             "properties": {


### PR DESCRIPTION
Closes #322.

#324 fixed the vacuous `if` on the `map` and `vector` conditionals in `schema/odcs-json-schema-v3.2.0.json`, but `schema/odcs-json-schema-latest.json` carries the same `$defs/SchemaBaseProperty` block and was left untouched. `latest` is what most tooling resolves to by default, so the bug reported in #322 still reproduces against it. This applies the identical guard there.

```diff
             "logicalType": {
               "const": "map"
             }
-          }
+          },
+          "required": [
+            "logicalType"
+          ]
```

The two schema files now differ only by the pre-existing `"deprecated": true` on `dataProduct.name`, which is out of scope here.

## Verification

Against `schema/odcs-json-schema-latest.json`, using the repro from #322:

| Document | before | after |
|---|---|---|
| property with `physicalType` only (#322 repro) | ❌ `'map' is a required property` | ✅ valid |
| `docs/examples/schema/property-without-logicaltype.odcs.yaml` (the #324 guard) | ❌ 3 × `'map' is a required property` | ✅ valid |
| `src/script/negative-tests/map-missing-block.odcs.yaml` | ❌ rejected (correct) | ❌ rejected (correct) |

`logicalType: map` without a `map` block is still invalid — the rule is unchanged, only the vacuous trigger is gone.

`validate-examples.sh` and `validate-negative.sh` both run green with `JSON_SCHEMA_VERSION=latest` and with the default `v3.2.0`.

## Why CI missed it

Both scripts default to `JSON_SCHEMA_VERSION=v3.2.0` and `.github/workflows/validate-examples.yaml` never overrides it, so `odcs-json-schema-latest.json` is not exercised by any job. Worth a follow-up to run the suite against `latest` as well, so the two files cannot drift again unnoticed.

## Not included

No CHANGELOG entry — the standard's semantics do not change, `logicalType` was always optional. Consistent with #324.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QiP3DuED6J7xbzmPtwuY41