### PR TITLE
fix(schema): make latest and v3.2.0 byte-identical, and enforce it in CI

### DIFF
--- a/.github/workflows/validate-examples.yaml
+++ b/.github/workflows/validate-examples.yaml
@@ -19,6 +19,8 @@ jobs:
       - name: Install ajv
         run: |
           npm i -g ajv-cli ajv-formats
+      - name: Validate schema parity (latest == versioned)
+        run: bash src/script/validate-schema-parity.sh
       - name: Validate examples
         run: bash src/script/validate-examples.sh
       - name: Validate negative tests

--- a/schema/odcs-json-schema-v3.2.0.json
+++ b/schema/odcs-json-schema-v3.2.0.json
@@ -51,7 +51,8 @@
     },
     "dataProduct": {
       "type": "string",
-      "description": "The name of the data product. DEPRECATED since v3.1.0."
+      "description": "The name of the data product. DEPRECATED since v3.1.0.",
+      "deprecated": true
     },
     "description": {
       "type": "object",

--- a/src/script/validate-schema-parity.sh
+++ b/src/script/validate-schema-parity.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Bitol Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# `odcs-json-schema-latest.json` MUST be identical to the schema of the version
+# under development. They are two names for one artifact: `latest` is what most
+# tooling resolves to by default, the versioned file is what the release pins.
+# Any difference between them means some consumers get a different standard than
+# others, which is what happened with #322 — the map/vector guard was fixed in
+# v3.2.0 and missed in latest.
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+schema_dir="${script_dir}/../../schema"
+json_schema_version=${JSON_SCHEMA_VERSION:-v3.2.0}
+
+latest="${schema_dir}/odcs-json-schema-latest.json"
+versioned="${schema_dir}/odcs-json-schema-${json_schema_version}.json"
+
+echo "Checking that odcs-json-schema-latest.json is identical to odcs-json-schema-${json_schema_version}.json"
+
+if [ ! -f "${versioned}" ]; then
+  echo -e "${RED}Missing ${versioned}${NC}"
+  exit 1
+fi
+
+if diff -u "${versioned}" "${latest}"; then
+  echo -e "${GREEN}Identical${NC}"
+  exit 0
+fi
+
+echo -e "${RED}odcs-json-schema-latest.json and odcs-json-schema-${json_schema_version}.json differ.${NC}"
+echo -e "${RED}They must be byte-identical: apply every schema change to BOTH files.${NC}"
+exit 1


### PR DESCRIPTION
`odcs-json-schema-latest.json` and `odcs-json-schema-v3.2.0.json` are two names for one artifact — `latest` is what most tooling resolves to by default, the versioned file is what the release pins. They must be **identical**, and they were not.

## The two drifts

| Delta | Where it was added | Where it was missing |
|---|---|---|
| #322 `map`/`vector` `"required": ["logicalType"]` guard | v3.2.0 (#324) | latest — fixed separately in #328 |
| `"deprecated": true` on `dataProduct` | latest (`e1fcce8`) | **v3.2.0 — fixed here** |

The `dataProduct` field is already described as `"DEPRECATED since v3.1.0."` and the file's three other deprecated fields (`team[]` array form, `slaDefaultElement`) all carry the flag, so adding it to v3.2.0 is the correct direction — latest was right, v3.2.0 was stale.

```diff
     "dataProduct": {
       "type": "string",
-      "description": "The name of the data product. DEPRECATED since v3.1.0."
+      "description": "The name of the data product. DEPRECATED since v3.1.0.",
+      "deprecated": true
     },
```

The two files are now **byte-identical** (`cmp` clean).

## Keeping them that way

Adds `src/script/validate-schema-parity.sh` — a `diff` of the two files, printing the offending hunks and a "apply every schema change to BOTH files" message on failure — and runs it in `validate-examples.yaml` ahead of the example and negative suites.

Verified both directions:

| Tree | parity script |
|---|---|
| this branch | ✅ exit 0, `Identical` |
| v3.2.0 reverted to its pre-parity content | ❌ exit 1, prints the diff |
| latest reverted to its pre-#328 content | ❌ exit 1, prints the diff |

Full gate on this branch:

| | `v3.2.0` | `latest` |
|---|---|---|
| `validate-schema-parity.sh` | ✅ | ✅ |
| `validate-examples.sh` | ✅ `Total failed=0` | ✅ `Total failed=0` |
| `validate-negative.sh` | ✅ `Total failed=0` | ✅ `Total failed=0` |

## Relationship to #329

#329 proposed a CI matrix running the suites against `latest` as well. This is a stronger and cheaper answer: if the files are provably identical, running the same suites twice over the same bytes adds nothing. I would close #329 in favour of this once it lands — happy to do the matrix instead if you prefer belt and braces.

No CHANGELOG entry: no semantics change. The annotation restates what the description already said, and RFC-0028's `deprecated` flag is already in the v3.2.0 changelog.

Refs #322, #329.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QiP3DuED6J7xbzmPtwuY41