### PR TITLE
docs: add a DQX example to the Custom quality section

### DIFF
--- a/docs/data-quality.md
+++ b/docs/data-quality.md
@@ -259,6 +259,27 @@ quality:
       maxValue: 50000                          # (Great Expectations in this situation)
 ```
 
+### DQX Example
+
+[DQX](https://github.com/databrickslabs/dqx) reads the `implementation` block as a parsed mapping rather than an opaque text block, so it is written as YAML rather than with a `|` literal. This schema-level example applies one check to several columns and scopes it to a subset of rows.
+
+```yaml
+quality:
+- id: dqx_high_alert_contact
+  type: custom
+  engine: dqx
+  description: A technician and an alert email are mandatory for high severity alerts.
+  implementation:
+    name: contact_required_for_high_alerts       # DQX rule name
+    criticality: error                           # error or warn
+    filter: alert_level in ('high', 'critical')  # only checked on these rows
+    check:
+      function: is_not_null_and_not_empty        # applied to each column below
+      for_each_column:
+        - technician_id
+        - alert_email
+```
+
 ## Scheduling
 
 The data contract can contain scheduling information for executing the rules. You can use `schedule` and `scheduler` for those operation. In previous versions of ODCS, the only allowed scheduler was cron and its syntax was `scheduleCronExpression`.

--- a/vendors.md
+++ b/vendors.md
@@ -17,6 +17,7 @@ A non-exhaustive, alphabetical list of organizations offering solutions natively
 * [Data Contract Playground](https://data-catering.github.io/data-contract-playground/) - Playground site for creating, exporting, and validating data contracts.
 * [DataVow](https://github.com/ludovicschmetz-stack/datavow) - Open-source CLI for ODCS v3.1 data contract enforcement with DuckDB validation, dbt test sync, GitHub Action, and Vow Score reporting
 * [DQC.ai | DQ PLATFORM](https://www.dqc.ai/dqc-platform) - [Enhancing Data Quality with ODCS: A Standard Ensured by the DQ Platform](https://www.dqc.ai/post/enhancing-data-quality-with-odcs-a-standard-ensured-by-the-dq-platform).
+* [DQX by Databricks Labs](https://github.com/databrickslabs/dqx) - Open Source data quality framework for PySpark on streaming and standard DataFrames. Generates checks natively from ODCS contracts, including `type: custom` with `engine: dqx`.
 * [Enkinex ODCS](https://odcs.enkinex.org) - Open-source KCL library for writing data governance as code. Provides modular, typed ODCS schemas (common, catalog, contract, iam, quality, server) with constraints, two-way
   validation, and YAML export.
 * [Entropy Data](https://www.entropy-data.com) - Data Product Marketplace built on Data Contracts. Allows contract-first development of data products.


### PR DESCRIPTION
## What

Adds a DQX example to the Custom section of the data quality page, alongside the existing Soda and Great Expectations examples, and lists DQX in `vendors.md`.

[DQX](https://github.com/databrickslabs/dqx) (Databricks Labs) consumes ODCS natively and generates checks from `type: custom` quality entries with `engine: dqx`, but it is not mentioned anywhere in the docs today.

## Two notes on the example's shape

- `implementation` is a parsed mapping rather than a `|` text block. That is what DQX reads, the JSON schema declares `implementation` as `oneOf: [string, object]`, and `docs/examples/quality/column-custom.odcs.yaml` already uses both forms. A sentence in the docs explains the difference so it does not read as an inconsistency with the two examples above it.
- `for_each_column` sits inside `check`, which is where DQX expects it.

## Validation

I extracted the snippet back out of the edited page and checked it against:

- `schema/odcs-json-schema-v3.2.0.json` (the `validate-examples.sh` default) and `schema/odcs-json-schema-v3.1.0.json` - both pass
- the `open-data-contract-standard` Python model - parses
- DQX's own contract rules generator - produces exactly one check rule carrying the filter, the criticality and both columns
- DQX's `validate_checks` - no errors

Note the snippet itself is not covered by the `validate-examples` job, which only walks `docs/examples/*/*.yaml`. Happy to add a DQX file there as well if you would like it under CI.

## Also noticed

Unrelated to this change and happy to raise separately: the `quality.implementation` row in the field reference table says type `string` and "A text (non-parsed) block of code", which does not match the schema's `oneOf: [string, object]`, nor the existing example in `docs/examples/quality/column-custom.odcs.yaml` that uses the mapping form.

---
This pull request and its description were written by Isaac.
