### PR TITLE
Promote dev to main — DQX custom quality example (#337)

### DIFF
--- a/docs/data-quality.md
+++ b/docs/data-quality.md
@@ -259,6 +259,27 @@ quality:
       maxValue: 50000                          # (Great Expectations in this situation)
 ```
 
+### DQX Example
+
+[DQX](https://github.com/databrickslabs/dqx) reads the `implementation` block as a parsed mapping rather than an opaque text block, so it is written as YAML rather than with a `|` literal. This schema-level example applies one check to several columns and scopes it to a subset of rows.
+
+```yaml
+quality:
+- id: dqx_high_alert_contact
+  type: custom
+  engine: dqx
+  description: A technician and an alert email are mandatory for high severity alerts.
+  implementation:
+    name: contact_required_for_high_alerts       # DQX rule name
+    criticality: error                           # error or warn
+    filter: alert_level in ('high', 'critical')  # only checked on these rows
+    check:
+      function: is_not_null_and_not_empty        # applied to each column below
+      for_each_column:
+        - technician_id
+        - alert_email
+```
+
 ## Scheduling
 
 The data contract can contain scheduling information for executing the rules. You can use `schedule` and `scheduler` for those operation. In previous versions of ODCS, the only allowed scheduler was cron and its syntax was `scheduleCronExpression`.

--- a/vendors.md
+++ b/vendors.md
@@ -17,6 +17,7 @@ A non-exhaustive, alphabetical list of organizations offering solutions natively
 * [Data Contract Playground](https://data-catering.github.io/data-contract-playground/) - Playground site for creating, exporting, and validating data contracts.
 * [DataVow](https://github.com/ludovicschmetz-stack/datavow) - Open-source CLI for ODCS v3.1 data contract enforcement with DuckDB validation, dbt test sync, GitHub Action, and Vow Score reporting
 * [DQC.ai | DQ PLATFORM](https://www.dqc.ai/dqc-platform) - [Enhancing Data Quality with ODCS: A Standard Ensured by the DQ Platform](https://www.dqc.ai/post/enhancing-data-quality-with-odcs-a-standard-ensured-by-the-dq-platform).
+* [DQX by Databricks Labs](https://github.com/databrickslabs/dqx) - Open Source data quality framework for PySpark on streaming and standard DataFrames. Generates checks natively from ODCS contracts, including `type: custom` with `engine: dqx`.
 * [Enkinex ODCS](https://odcs.enkinex.org) - Open-source KCL library for writing data governance as code. Provides modular, typed ODCS schemas (common, catalog, contract, iam, quality, server) with constraints, two-way
   validation, and YAML export.
 * [Entropy Data](https://www.entropy-data.com) - Data Product Marketplace built on Data Contracts. Allows contract-first development of data products.


### PR DESCRIPTION
Promotes `dev` (`471418c`) to `main`. Docs-only, no schema or standard change.

Carries #337 (vb-dbrks):

- `docs/data-quality.md` — a DQX example in the Custom quality section (+21)
- `vendors.md` — DQX vendor entry (+1)

`dev` CI is green on `471418c` (validate-examples). `main` was last green on `f0bdad9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SErGFxMe33DgVG9VgoURr1